### PR TITLE
Register, Login api

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,4 +46,16 @@ dependencies {
 
     //sticky scoll view
     implementation 'com.github.amarjain07:StickyScrollView:1.0.3'
+    // Log
+    implementation 'com.squareup.okhttp3:logging-interceptor:3.12.1'
+    //KTX
+    implementation "androidx.fragment:fragment-ktx:1.4.1"
+    //Retrofit2
+    implementation 'com.squareup.retrofit2:retrofit:2.9.0'
+    // ViewModel
+    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.4.1")
+    //gson
+    implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
+
+
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -52,10 +52,11 @@ dependencies {
     implementation "androidx.fragment:fragment-ktx:1.4.1"
     //Retrofit2
     implementation 'com.squareup.retrofit2:retrofit:2.9.0'
+    //Gson
+    implementation 'com.squareup.retrofit2:converter-gson:2.3.0'
     // ViewModel
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.4.1")
     //gson
     implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
-
 
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,12 +2,15 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.aligatorapt.duckdam">
 
+    <uses-permission android:name="android.permission.INTERNET"/>
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_mainicon"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_mainicon_round"
         android:supportsRtl="true"
+        android:usesCleartextTraffic="true"
         android:theme="@style/Theme.Duckdam">
         <activity
             android:name=".MainActivity"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.INTERNET"/>
 
     <application
+        android:name=".sharedpreferences.MyApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_mainicon"
         android:label="@string/app_name"

--- a/app/src/main/java/com/aligatorapt/duckdam/dto/ErrorResponseDto.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/dto/ErrorResponseDto.kt
@@ -1,0 +1,6 @@
+package com.aligatorapt.duckdam.dto
+
+data class ErrorResponseDto (
+    val statusCode: Int?,
+    val message: String?
+)

--- a/app/src/main/java/com/aligatorapt/duckdam/dto/auth/EmailTokenDto.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/dto/auth/EmailTokenDto.kt
@@ -1,0 +1,6 @@
+package com.aligatorapt.duckdam.dto.auth
+
+data class EmailTokenDto (
+    var email: String,
+    var token: String
+)

--- a/app/src/main/java/com/aligatorapt/duckdam/dto/user/LoginRequestDto.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/dto/user/LoginRequestDto.kt
@@ -1,0 +1,6 @@
+package com.aligatorapt.duckdam.dto.user
+
+data class LoginRequestDto (
+    val email: String,
+    val password: String
+)

--- a/app/src/main/java/com/aligatorapt/duckdam/dto/user/LoginResponseDto.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/dto/user/LoginResponseDto.kt
@@ -1,0 +1,6 @@
+package com.aligatorapt.duckdam.dto.user
+
+data class LoginResponseDto (
+    val token: String,
+    val refreshToken: String
+)

--- a/app/src/main/java/com/aligatorapt/duckdam/dto/user/RegisterDto.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/dto/user/RegisterDto.kt
@@ -1,0 +1,8 @@
+package com.aligatorapt.duckdam.dto.user
+
+data class RegisterDto (
+    val name: String,
+    val password: String,
+    val email: String,
+    val profile: String?
+)

--- a/app/src/main/java/com/aligatorapt/duckdam/dto/user/UserResponseDto.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/dto/user/UserResponseDto.kt
@@ -1,0 +1,7 @@
+package com.aligatorapt.duckdam.dto.user
+
+data class UserResponseDto (
+    val uid: Long,
+    val name: String,
+    val profile: String?
+)

--- a/app/src/main/java/com/aligatorapt/duckdam/model/EmailModel.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/model/EmailModel.kt
@@ -1,0 +1,45 @@
+package com.aligatorapt.duckdam.model
+
+import android.util.Log
+import com.aligatorapt.duckdam.dto.auth.EmailTokenDto
+import com.aligatorapt.duckdam.retrofit.RetrofitClient
+import com.aligatorapt.duckdam.retrofit.callback.ApiCallback
+import okhttp3.ResponseBody
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
+
+object EmailModel {
+    fun generateEmailAuth(_email: String, callback: ApiCallback){
+        RetrofitClient.EMAIL_INTERFACE_SERVICE.generateEmailAuth(_email).enqueue(object: Callback<ResponseBody> {
+            override fun onResponse(
+                call: Call<ResponseBody>,
+                response: Response<ResponseBody>
+            ) {
+                Log.d("Response::", "Response::" + response.body().toString())
+            }
+            override fun onFailure(call: Call<ResponseBody>, t: Throwable) {
+                Log.d("onFailure::", "onFailure: $t")
+            }
+        })
+    }
+
+    fun verifyEmailToken(_emailTokenDto: EmailTokenDto, callback: ApiCallback): Boolean{
+        var isVerified = false
+        RetrofitClient.EMAIL_INTERFACE_SERVICE.verifyEmailToken(_emailTokenDto).enqueue(object: Callback<ResponseBody> {
+            override fun onResponse(
+                call: Call<ResponseBody>,
+                response: Response<ResponseBody>
+            ) {
+                Log.d("Response::", "Response::" + response.body().toString())
+                isVerified = true
+            }
+
+            override fun onFailure(call: Call<ResponseBody>, t: Throwable) {
+                Log.d("onFailure::", "onFailure: $t")
+                isVerified = false
+            }
+        })
+        return isVerified
+    }
+}

--- a/app/src/main/java/com/aligatorapt/duckdam/model/EmailModel.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/model/EmailModel.kt
@@ -4,6 +4,8 @@ import android.util.Log
 import com.aligatorapt.duckdam.dto.auth.EmailTokenDto
 import com.aligatorapt.duckdam.retrofit.RetrofitClient
 import com.aligatorapt.duckdam.retrofit.callback.ApiCallback
+import okhttp3.MediaType
+import okhttp3.RequestBody
 import okhttp3.ResponseBody
 import retrofit2.Call
 import retrofit2.Callback
@@ -11,35 +13,45 @@ import retrofit2.Response
 
 object EmailModel {
     fun generateEmailAuth(_email: String, callback: ApiCallback){
-        RetrofitClient.EMAIL_INTERFACE_SERVICE.generateEmailAuth(_email).enqueue(object: Callback<ResponseBody> {
+
+        val body: RequestBody = RequestBody.create(MediaType.parse("text/plain"), _email)
+
+        RetrofitClient.EMAIL_INTERFACE_SERVICE.generateEmailAuth(body).enqueue(object: Callback<ResponseBody> {
             override fun onResponse(
                 call: Call<ResponseBody>,
                 response: Response<ResponseBody>
             ) {
                 Log.d("Response::", "Response::" + response.body().toString())
+                if (response.isSuccessful) {
+                    callback.apiCallback(true)
+                } else {
+                    callback.apiCallback(false)
+                }
             }
             override fun onFailure(call: Call<ResponseBody>, t: Throwable) {
                 Log.d("onFailure::", "onFailure: $t")
+                callback.apiCallback(false)
             }
         })
     }
 
-    fun verifyEmailToken(_emailTokenDto: EmailTokenDto, callback: ApiCallback): Boolean{
-        var isVerified = false
+    fun verifyEmailToken(_emailTokenDto: EmailTokenDto, callback: ApiCallback){
         RetrofitClient.EMAIL_INTERFACE_SERVICE.verifyEmailToken(_emailTokenDto).enqueue(object: Callback<ResponseBody> {
             override fun onResponse(
                 call: Call<ResponseBody>,
                 response: Response<ResponseBody>
             ) {
                 Log.d("Response::", "Response::" + response.body().toString())
-                isVerified = true
+                if (response.isSuccessful) {
+                    callback.apiCallback(true)
+                } else {
+                    callback.apiCallback(false)
+                }
             }
-
             override fun onFailure(call: Call<ResponseBody>, t: Throwable) {
                 Log.d("onFailure::", "onFailure: $t")
-                isVerified = false
+                callback.apiCallback(false)
             }
         })
-        return isVerified
     }
 }

--- a/app/src/main/java/com/aligatorapt/duckdam/model/UserModel.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/model/UserModel.kt
@@ -6,23 +6,41 @@ import com.aligatorapt.duckdam.dto.user.LoginResponseDto
 import com.aligatorapt.duckdam.dto.user.RegisterDto
 import com.aligatorapt.duckdam.retrofit.RetrofitClient
 import com.aligatorapt.duckdam.retrofit.callback.ApiCallback
+import com.aligatorapt.duckdam.retrofit.callback.RegisterCallback
 import com.aligatorapt.duckdam.sharedpreferences.MyApplication
 import okhttp3.ResponseBody
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
+import com.aligatorapt.duckdam.dto.ErrorResponseDto
+import com.aligatorapt.duckdam.sharedpreferences.ErrorUtil
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import retrofit2.Converter
+
 
 object UserModel{
-    fun register( _userInfo: RegisterDto, callback: ApiCallback){
+    fun register( _userInfo: RegisterDto, callback: RegisterCallback){
         RetrofitClient.USER_INTERFACE_SERVICE.register(_userInfo).enqueue(object: Callback<ResponseBody> {
             override fun onResponse(
                 call: Call<ResponseBody>,
                 response: Response<ResponseBody>
             ) {
                 Log.d("Response::", "Response::" + response.body().toString())
+                if (response.isSuccessful) {
+                    callback.registerCallback(true, isNickname = false)
+                } else {
+                    val error: ErrorResponseDto? = ErrorUtil.parseError(response)
+                    Log.d("errorResponse::", "errorResponse::" + error!!.statusCode + error.message)
+                    if(error.statusCode == 409){
+                        callback.registerCallback(false, isNickname = true)
+                    }
+                    else callback.registerCallback(false, isNickname = false)
+                }
             }
             override fun onFailure(call: Call<ResponseBody>, t: Throwable) {
                 Log.d("onFailure::", "onFailure: $t")
+                callback.registerCallback(false, isNickname = false)
             }
         })
     }
@@ -44,6 +62,7 @@ object UserModel{
             }
             override fun onFailure(call: Call<LoginResponseDto>, t: Throwable) {
                 Log.d("onFailure::", "onFailure: $t")
+                callback.apiCallback(false)
             }
         })
     }

--- a/app/src/main/java/com/aligatorapt/duckdam/model/UserModel.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/model/UserModel.kt
@@ -1,0 +1,50 @@
+package com.aligatorapt.duckdam.model
+
+import android.util.Log
+import com.aligatorapt.duckdam.dto.user.LoginRequestDto
+import com.aligatorapt.duckdam.dto.user.LoginResponseDto
+import com.aligatorapt.duckdam.dto.user.RegisterDto
+import com.aligatorapt.duckdam.retrofit.RetrofitClient
+import com.aligatorapt.duckdam.retrofit.callback.ApiCallback
+import com.aligatorapt.duckdam.sharedpreferences.MyApplication
+import okhttp3.ResponseBody
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
+
+object UserModel{
+    fun register( _userInfo: RegisterDto, callback: ApiCallback){
+        RetrofitClient.USER_INTERFACE_SERVICE.register(_userInfo).enqueue(object: Callback<ResponseBody> {
+            override fun onResponse(
+                call: Call<ResponseBody>,
+                response: Response<ResponseBody>
+            ) {
+                Log.d("Response::", "Response::" + response.body().toString())
+            }
+            override fun onFailure(call: Call<ResponseBody>, t: Throwable) {
+                Log.d("onFailure::", "onFailure: $t")
+            }
+        })
+    }
+
+    fun login(_loginRequestDto: LoginRequestDto, callback: ApiCallback){
+        RetrofitClient.USER_INTERFACE_SERVICE.login(_loginRequestDto).enqueue(object :Callback<LoginResponseDto>{
+            override fun onResponse(
+                call: Call<LoginResponseDto>,
+                response: Response<LoginResponseDto>
+            ) {
+                Log.d("Response::", "Response::" + response.body().toString())
+                if(response.isSuccessful){
+                    MyApplication.prefs.setString("token", response.body()!!.token)
+                    MyApplication.prefs.setString("refreshToken", response.body()!!.refreshToken)
+                    callback.apiCallback(true)
+                }else{
+                    callback.apiCallback(false)
+                }
+            }
+            override fun onFailure(call: Call<LoginResponseDto>, t: Throwable) {
+                Log.d("onFailure::", "onFailure: $t")
+            }
+        })
+    }
+}

--- a/app/src/main/java/com/aligatorapt/duckdam/retrofit/RetrofitClient.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/retrofit/RetrofitClient.kt
@@ -1,5 +1,6 @@
 package com.aligatorapt.duckdam.retrofit
 
+import com.aligatorapt.duckdam.dto.ErrorResponseDto
 import com.aligatorapt.duckdam.retrofit.`interface`.EmailInterface
 import com.aligatorapt.duckdam.retrofit.`interface`.UserInterface
 import okhttp3.OkHttpClient
@@ -7,19 +8,25 @@ import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import java.util.concurrent.TimeUnit
+import com.aligatorapt.duckdam.retrofit.*
+
+import com.aligatorapt.duckdam.retrofit.*
+
+
+
 
 object RetrofitClient {
-    private const val BASE_URL:String = "http://USER_IP:8080"
+    private const val BASE_URL:String = "http://172.30.1.18:8080"
 
     private val loggingInterceptor = HttpLoggingInterceptor()
 
-    val client: OkHttpClient = OkHttpClient.Builder()
+    private val client: OkHttpClient = OkHttpClient.Builder()
         .readTimeout(30000, TimeUnit.MILLISECONDS)
         .connectTimeout(30000, TimeUnit.MILLISECONDS)
         .addInterceptor(loggingInterceptor)
         .build()
 
-    private val retrofit: Retrofit.Builder by lazy{
+    val builder: Retrofit.Builder by lazy{
         loggingInterceptor.level = HttpLoggingInterceptor.Level.BODY
         Retrofit.Builder()
             .baseUrl(BASE_URL)
@@ -27,12 +34,14 @@ object RetrofitClient {
             .addConverterFactory(GsonConverterFactory.create())
     }
 
+    val retrofit: Retrofit = builder.build()
+
     val EMAIL_INTERFACE_SERVICE: EmailInterface by lazy{
-        retrofit.build().create(EmailInterface::class.java)
+        retrofit.create(EmailInterface::class.java)
     }
 
     val USER_INTERFACE_SERVICE: UserInterface by lazy{
-        retrofit.build().create(UserInterface::class.java)
+        retrofit.create(UserInterface::class.java)
     }
 
 }

--- a/app/src/main/java/com/aligatorapt/duckdam/retrofit/RetrofitClient.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/retrofit/RetrofitClient.kt
@@ -1,0 +1,38 @@
+package com.aligatorapt.duckdam.retrofit
+
+import com.aligatorapt.duckdam.retrofit.`interface`.EmailInterface
+import com.aligatorapt.duckdam.retrofit.`interface`.UserInterface
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import java.util.concurrent.TimeUnit
+
+object RetrofitClient {
+    private const val BASE_URL:String = "http://USER_IP:8080"
+
+    private val loggingInterceptor = HttpLoggingInterceptor()
+
+    val client: OkHttpClient = OkHttpClient.Builder()
+        .readTimeout(30000, TimeUnit.MILLISECONDS)
+        .connectTimeout(30000, TimeUnit.MILLISECONDS)
+        .addInterceptor(loggingInterceptor)
+        .build()
+
+    private val retrofit: Retrofit.Builder by lazy{
+        loggingInterceptor.level = HttpLoggingInterceptor.Level.BODY
+        Retrofit.Builder()
+            .baseUrl(BASE_URL)
+            .client(client)
+            .addConverterFactory(GsonConverterFactory.create())
+    }
+
+    val EMAIL_INTERFACE_SERVICE: EmailInterface by lazy{
+        retrofit.build().create(EmailInterface::class.java)
+    }
+
+    val USER_INTERFACE_SERVICE: UserInterface by lazy{
+        retrofit.build().create(UserInterface::class.java)
+    }
+
+}

--- a/app/src/main/java/com/aligatorapt/duckdam/retrofit/callback/ApiCallback.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/retrofit/callback/ApiCallback.kt
@@ -1,0 +1,5 @@
+package com.aligatorapt.duckdam.retrofit.callback
+
+interface ApiCallback {
+    fun apiCallback(flag: Boolean)
+}

--- a/app/src/main/java/com/aligatorapt/duckdam/retrofit/callback/RegisterCallback.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/retrofit/callback/RegisterCallback.kt
@@ -1,0 +1,6 @@
+package com.aligatorapt.duckdam.retrofit.callback
+
+interface RegisterCallback {
+    //isNickname : 닉네임 중복 여부
+    fun registerCallback(flag: Boolean, isNickname: Boolean)
+}

--- a/app/src/main/java/com/aligatorapt/duckdam/retrofit/interface/EmailInterface.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/retrofit/interface/EmailInterface.kt
@@ -1,0 +1,19 @@
+package com.aligatorapt.duckdam.retrofit.`interface`
+
+import com.aligatorapt.duckdam.dto.auth.EmailTokenDto
+import okhttp3.ResponseBody
+import retrofit2.Call
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+interface EmailInterface {
+    @POST("/user/email")
+    fun generateEmailAuth(
+        @Body targetEmail: String
+    ) : Call<ResponseBody>
+
+    @POST("/user/email/verify")
+    fun verifyEmailToken(
+        @Body emailTokenDto: EmailTokenDto
+    ) : Call<ResponseBody>
+}

--- a/app/src/main/java/com/aligatorapt/duckdam/retrofit/interface/EmailInterface.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/retrofit/interface/EmailInterface.kt
@@ -1,6 +1,7 @@
 package com.aligatorapt.duckdam.retrofit.`interface`
 
 import com.aligatorapt.duckdam.dto.auth.EmailTokenDto
+import okhttp3.RequestBody
 import okhttp3.ResponseBody
 import retrofit2.Call
 import retrofit2.http.Body
@@ -9,7 +10,7 @@ import retrofit2.http.POST
 interface EmailInterface {
     @POST("/user/email")
     fun generateEmailAuth(
-        @Body targetEmail: String
+        @Body targetEmail: RequestBody
     ) : Call<ResponseBody>
 
     @POST("/user/email/verify")

--- a/app/src/main/java/com/aligatorapt/duckdam/retrofit/interface/UserInterface.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/retrofit/interface/UserInterface.kt
@@ -1,0 +1,46 @@
+package com.aligatorapt.duckdam.retrofit.`interface`
+
+import com.aligatorapt.duckdam.dto.user.LoginRequestDto
+import com.aligatorapt.duckdam.dto.user.LoginResponseDto
+import com.aligatorapt.duckdam.dto.user.RegisterDto
+import com.aligatorapt.duckdam.dto.user.UserResponseDto
+import okhttp3.ResponseBody
+import retrofit2.Call
+import retrofit2.http.Body
+import retrofit2.http.HeaderMap
+import retrofit2.http.POST
+import retrofit2.http.Path
+
+interface UserInterface {
+    @POST("/user/register")
+    fun register(
+        @Body registerDto: RegisterDto
+    ): Call<ResponseBody>
+
+    @POST("/user/login")
+    fun login(
+        @Body loginRequestDto: LoginRequestDto
+    ): Call<LoginResponseDto>
+
+    @POST("/user/refresh")
+    fun refreshToken(
+        @Body refreshToken: String
+    ): Call<LoginResponseDto>
+
+    @POST("/users/{query}")
+    fun searchByName(
+        @HeaderMap httpHeaders: HashMap<String, String>,
+        @Path("query") query: String
+    ): Call<List<UserResponseDto>>
+
+    @POST("/user/stickers")
+    fun getStickerList(
+        @HeaderMap httpHeaders: HashMap<String, String>
+    ): Call<List<Boolean>>
+
+    @POST("/user/slot")
+    fun isEligibleForSlot(
+        @HeaderMap httpHeaders: HashMap<String, String>,
+    ): Call<Boolean>
+
+}

--- a/app/src/main/java/com/aligatorapt/duckdam/sharedpreferences/ErrorUtil.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/sharedpreferences/ErrorUtil.kt
@@ -1,0 +1,23 @@
+package com.aligatorapt.duckdam.sharedpreferences
+
+import com.aligatorapt.duckdam.dto.ErrorResponseDto
+import com.aligatorapt.duckdam.retrofit.RetrofitClient
+import com.aligatorapt.duckdam.retrofit.RetrofitClient.retrofit
+import retrofit2.Response
+import okhttp3.ResponseBody
+
+import retrofit2.Converter
+import java.io.IOException
+
+
+object ErrorUtil {
+    fun parseError(response: Response<*>): ErrorResponseDto? {
+        val converter: Converter<ResponseBody?, ErrorResponseDto>
+            = retrofit.responseBodyConverter(ErrorResponseDto::class.java, arrayOfNulls<Annotation>(0))
+        return try {
+            converter.convert(response.errorBody())
+        } catch (e: IOException) {
+            return null
+        }
+    }
+}

--- a/app/src/main/java/com/aligatorapt/duckdam/sharedpreferences/MyApplication.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/sharedpreferences/MyApplication.kt
@@ -1,0 +1,15 @@
+package com.aligatorapt.duckdam.sharedpreferences
+
+import android.app.Application
+
+class MyApplication : Application() {
+    companion object {
+        lateinit var prefs: PreferenceUtil
+    }
+
+    override fun onCreate() {
+        prefs = PreferenceUtil(applicationContext)
+        super.onCreate()
+    }
+}
+

--- a/app/src/main/java/com/aligatorapt/duckdam/sharedpreferences/PreferenceUtil.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/sharedpreferences/PreferenceUtil.kt
@@ -1,0 +1,17 @@
+package com.aligatorapt.duckdam.sharedpreferences
+
+import android.content.Context
+import android.content.SharedPreferences
+
+class PreferenceUtil(context: Context) {
+    private val prefs: SharedPreferences =
+        context.getSharedPreferences("prefs_name", Context.MODE_PRIVATE)
+
+    fun getString(key: String, defValue: String): String {
+        return prefs.getString(key, defValue).toString()
+    }
+
+    fun setString(key: String, str: String) {
+        prefs.edit().putString(key, str).apply()
+    }
+}

--- a/app/src/main/java/com/aligatorapt/duckdam/view/activity/LoginActivity.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/view/activity/LoginActivity.kt
@@ -2,12 +2,20 @@ package com.aligatorapt.duckdam.view.activity
 
 import android.content.Intent
 import android.os.Bundle
+import android.widget.Toast
+import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import com.aligatorapt.duckdam.R
 import com.aligatorapt.duckdam.databinding.ActivityLoginBinding
+import com.aligatorapt.duckdam.dto.user.LoginRequestDto
+import com.aligatorapt.duckdam.retrofit.callback.ApiCallback
+import com.aligatorapt.duckdam.sharedpreferences.MyApplication
+import com.aligatorapt.duckdam.viewModel.LoginViewModel
 
 class LoginActivity: AppCompatActivity() {
     lateinit var binding: ActivityLoginBinding
+
+    private val model: LoginViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -15,13 +23,29 @@ class LoginActivity: AppCompatActivity() {
         setContentView(binding.root)
 
         binding.apply {
+
             loginSignup.setOnClickListener {
                 val intent = Intent(this@LoginActivity,SignUpActivity::class.java)
                 startActivity(intent)
             }
+
             loginLoginTv.setOnClickListener {
-                val intent = Intent(this@LoginActivity, NavigationActivity::class.java)
-                startActivity(intent)
+                model.login(
+                    LoginRequestDto(
+                        email = loginEmail.text.toString(),
+                        password = loginPw.text.toString()
+                    ),object: ApiCallback{
+                        override fun apiCallback(flag: Boolean) {
+                            if(flag){
+                                MyApplication.prefs.setString("email",loginEmail.text.toString())
+                                val intent = Intent(this@LoginActivity, NavigationActivity::class.java)
+                                startActivity(intent)
+                            }else{
+                                Toast.makeText(this@LoginActivity, "회원 정보가 일치하지 않습니다.", Toast.LENGTH_LONG).show()
+                            }
+                        }
+                    }
+                )
             }
         }
     }

--- a/app/src/main/java/com/aligatorapt/duckdam/view/activity/SignUpActivity.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/view/activity/SignUpActivity.kt
@@ -27,7 +27,7 @@ import java.util.regex.Pattern
 
 class SignUpActivity: AppCompatActivity() {
     lateinit var binding: ActivitySignupBinding
-    private var arr = booleanArrayOf(false,false,false,false,false,false)
+    private var arr = booleanArrayOf(false,false,false,false,false)
     private val PROFILE_IMAGE = 100
     private var isActivateBtn = false
 
@@ -38,42 +38,12 @@ class SignUpActivity: AppCompatActivity() {
         binding = ActivitySignupBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        EmailCode()
+        emailCode()
         check()
         register()
     }
 
-    private fun register() {
-        binding.apply {
-            signupFinal.setOnClickListener {
-                if(isActivateBtn){
-                    model.registser(
-                        RegisterDto(
-                            name = signupNickname.text.toString(),
-                            password = signupPwEt.text.toString(),
-                            email = model.email.value.toString(),
-                            profile = model.profile.value
-                        ), object : RegisterCallback {
-                            override fun registerCallback(flag: Boolean, isNickname: Boolean) {
-                                if (flag) {
-                                    signupNicknameError.visibility = View.GONE
-                                    val intent = Intent(this@SignUpActivity,LoginActivity::class.java)
-                                    finish()
-                                    startActivity(intent)
-                                }else if(!flag && isNickname){
-                                    signupNicknameError.visibility = View.VISIBLE
-                                    arr[4] = false
-                                    setIsActivateBtn()
-                                }
-                            }
-                        }
-                    )
-                }
-            }
-        }
-    }
-
-    private fun EmailCode() {
+    private fun emailCode() {
         binding.apply {
             
             //인증코드 전송
@@ -168,6 +138,36 @@ class SignUpActivity: AppCompatActivity() {
         }
     }
 
+    private fun register() {
+        binding.apply {
+            signupFinal.setOnClickListener {
+                if(isActivateBtn){
+                    model.registser(
+                        RegisterDto(
+                            name = signupNickname.text.toString(),
+                            password = signupPwEt.text.toString(),
+                            email = model.email.value.toString(),
+                            profile = model.profile.value
+                        ), object : RegisterCallback {
+                            override fun registerCallback(flag: Boolean, isNickname: Boolean) {
+                                if (flag) {
+                                    signupNicknameError.visibility = View.GONE
+                                    val intent = Intent(this@SignUpActivity,LoginActivity::class.java)
+                                    finish()
+                                    startActivity(intent)
+                                }else if(!flag && isNickname){
+                                    signupNicknameError.visibility = View.VISIBLE
+                                    arr[4] = false
+                                    setIsActivateBtn()
+                                }
+                            }
+                        }
+                    )
+                }
+            }
+        }
+    }
+
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
         if (requestCode == PROFILE_IMAGE) {
@@ -187,15 +187,12 @@ class SignUpActivity: AppCompatActivity() {
                             model.setProfile(bitmap.toString())
                             binding.signupImage.setImageBitmap(bitmap)
                         }
-                        arr[5] = true
                     }
                 } catch (e: Exception) {
-                    arr[5] = false
                     e.printStackTrace()
                 }
             } else if (resultCode == RESULT_CANCELED) {
-                Toast.makeText(this, "사진 선택 취소", Toast.LENGTH_LONG).show()
-                arr[5] = false
+                Toast.makeText(this, "사진 선택이 취소되었습니다.", Toast.LENGTH_LONG).show()
             }
         }
         setIsActivateBtn()
@@ -221,7 +218,7 @@ class SignUpActivity: AppCompatActivity() {
     }
 
     private fun setIsActivateBtn(){
-        Log.e("SETISACTIVE",arr[0].toString()+arr[1].toString()+arr[2].toString()+arr[3].toString()+arr[4].toString()+arr[5].toString())
+        Log.e("SETISACTIVE",arr[0].toString()+arr[1].toString()+arr[2].toString()+arr[3].toString()+arr[4].toString())
         isActivateBtn = true
         for(element in arr){
             if(!element){

--- a/app/src/main/java/com/aligatorapt/duckdam/view/activity/SignUpActivity.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/view/activity/SignUpActivity.kt
@@ -20,6 +20,7 @@ import com.aligatorapt.duckdam.dto.auth.EmailTokenDto
 import com.aligatorapt.duckdam.dto.user.RegisterDto
 import com.aligatorapt.duckdam.model.UserModel.register
 import com.aligatorapt.duckdam.retrofit.callback.ApiCallback
+import com.aligatorapt.duckdam.retrofit.callback.RegisterCallback
 import com.aligatorapt.duckdam.viewModel.RegisterViewModel
 import java.lang.Exception
 import java.util.regex.Pattern
@@ -52,12 +53,17 @@ class SignUpActivity: AppCompatActivity() {
                             password = signupPwEt.text.toString(),
                             email = model.email.value.toString(),
                             profile = model.profile.value
-                        ), object : ApiCallback {
-                            override fun apiCallback(flag: Boolean) {
+                        ), object : RegisterCallback {
+                            override fun registerCallback(flag: Boolean, isNickname: Boolean) {
                                 if (flag) {
+                                    signupNicknameError.visibility = View.GONE
                                     val intent = Intent(this@SignUpActivity,LoginActivity::class.java)
                                     finish()
                                     startActivity(intent)
+                                }else if(!flag && isNickname){
+                                    signupNicknameError.visibility = View.VISIBLE
+                                    arr[4] = false
+                                    setIsActivateBtn()
                                 }
                             }
                         }
@@ -216,6 +222,7 @@ class SignUpActivity: AppCompatActivity() {
 
     private fun setIsActivateBtn(){
         Log.e("SETISACTIVE",arr[0].toString()+arr[1].toString()+arr[2].toString()+arr[3].toString()+arr[4].toString()+arr[5].toString())
+        isActivateBtn = true
         for(element in arr){
             if(!element){
                 isActivateBtn = false
@@ -226,7 +233,7 @@ class SignUpActivity: AppCompatActivity() {
             binding.signupFinal.isClickable = true
             binding.signupFinal.setBackgroundColor(ContextCompat.getColor(this, R.color.main))
         }else {
-            binding.signupFinal.isClickable = false
+            binding.signupFinal.isClickable = true
             binding.signupFinal.setBackgroundColor(ContextCompat.getColor(this, R.color.gray))
         }
     }

--- a/app/src/main/java/com/aligatorapt/duckdam/viewModel/LoginViewModel.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/viewModel/LoginViewModel.kt
@@ -1,0 +1,23 @@
+package com.aligatorapt.duckdam.viewModel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.aligatorapt.duckdam.dto.user.LoginRequestDto
+import com.aligatorapt.duckdam.model.UserModel
+import com.aligatorapt.duckdam.retrofit.callback.ApiCallback
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+class LoginViewModel: ViewModel() {
+    private var dispatcher: CoroutineDispatcher = Dispatchers.IO
+
+    fun login(_loginRequestDto: LoginRequestDto, callback: ApiCallback){
+        viewModelScope.launch {
+            withContext(dispatcher){
+                UserModel.login(_loginRequestDto, callback)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/aligatorapt/duckdam/viewModel/RegisterViewModel.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/viewModel/RegisterViewModel.kt
@@ -19,7 +19,7 @@ class RegisterViewModel: ViewModel() {
     private var dispatcher: CoroutineDispatcher = Dispatchers.IO
 
     val email = MutableLiveData<String>()
-    val profile = MutableLiveData<String>()
+    val profile = MutableLiveData<String?>()
 
     fun setEmail(_email: String){
         email.value = _email

--- a/app/src/main/java/com/aligatorapt/duckdam/viewModel/RegisterViewModel.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/viewModel/RegisterViewModel.kt
@@ -9,6 +9,7 @@ import com.aligatorapt.duckdam.dto.user.RegisterDto
 import com.aligatorapt.duckdam.model.EmailModel
 import com.aligatorapt.duckdam.model.UserModel
 import com.aligatorapt.duckdam.retrofit.callback.ApiCallback
+import com.aligatorapt.duckdam.retrofit.callback.RegisterCallback
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -44,7 +45,7 @@ class RegisterViewModel: ViewModel() {
         }
     }
 
-    fun registser(_userInfo: RegisterDto, callback: ApiCallback){
+    fun registser(_userInfo: RegisterDto, callback: RegisterCallback){
         viewModelScope.launch {
             withContext(dispatcher){
                 UserModel.register(_userInfo, callback)

--- a/app/src/main/java/com/aligatorapt/duckdam/viewModel/RegisterViewModel.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/viewModel/RegisterViewModel.kt
@@ -1,0 +1,55 @@
+package com.aligatorapt.duckdam.viewModel
+
+import android.graphics.Bitmap
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.aligatorapt.duckdam.dto.auth.EmailTokenDto
+import com.aligatorapt.duckdam.dto.user.RegisterDto
+import com.aligatorapt.duckdam.model.EmailModel
+import com.aligatorapt.duckdam.model.UserModel
+import com.aligatorapt.duckdam.retrofit.callback.ApiCallback
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+class RegisterViewModel: ViewModel() {
+    private var dispatcher: CoroutineDispatcher = Dispatchers.IO
+
+    val email = MutableLiveData<String>()
+    val profile = MutableLiveData<String>()
+
+    fun setEmail(_email: String){
+        email.value = _email
+    }
+
+    fun setProfile(_profile: String){
+        profile.value = _profile
+    }
+
+    fun generateEmailAuth(_email: String, callback: ApiCallback){
+        viewModelScope.launch {
+            withContext(dispatcher){
+                EmailModel.generateEmailAuth(_email, callback)
+            }
+        }
+    }
+
+    fun verifyEmailToken(_emailTokenDto: EmailTokenDto, callback: ApiCallback){
+        viewModelScope.launch {
+            withContext(dispatcher){
+                EmailModel.verifyEmailToken(_emailTokenDto, callback)
+            }
+        }
+    }
+
+    fun registser(_userInfo: RegisterDto, callback: ApiCallback){
+        viewModelScope.launch {
+            withContext(dispatcher){
+                UserModel.register(_userInfo, callback)
+            }
+        }
+    }
+
+}

--- a/app/src/main/res/layout/activity_signup.xml
+++ b/app/src/main/res/layout/activity_signup.xml
@@ -123,17 +123,18 @@
                 android:id="@+id/signup_code_tv"
                 android:layout_width="0dp"
                 android:layout_height="50dp"
-                android:paddingVertical="13dp"
-                android:paddingHorizontal="24dp"
-                android:gravity="center"
-                android:text="확인"
-                android:textSize="14sp"
-                android:textColor="@color/white"
-                android:background="@drawable/sub1_solid_box_10dp"
                 android:layout_marginEnd="35dp"
+                android:background="@drawable/sub1_solid_box_10dp"
+                android:gravity="center"
+                android:paddingHorizontal="24dp"
+                android:paddingVertical="13dp"
+                android:text="확인"
+                android:textColor="@color/white"
+                android:textSize="14sp"
+                app:layout_constraintBottom_toBottomOf="@id/signup_code"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toTopOf="@id/signup_code"
-                app:layout_constraintBottom_toBottomOf="@id/signup_code"/>
+                app:layout_constraintVertical_bias="0.0" />
 
 
             <TextView

--- a/app/src/main/res/layout/fragment_scroll_horizontal.xml
+++ b/app/src/main/res/layout/fragment_scroll_horizontal.xml
@@ -147,6 +147,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="260dp"
                 android:background="@drawable/white_box"
+                android:lineSpacingExtra="3dp"
                 android:paddingHorizontal="32dp"
                 android:paddingTop="64dp"
                 android:paddingBottom="32dp"


### PR DESCRIPTION
## 개요
- 회원가입, 로그인 API 연결

## 상세내용
- duckbox 와 동일하게 MVVM 구조로 진행하였습니다.
- 이메일 코드 전송, 이메일 인증 코드 확인, 회원가입, 로그인, 닉네임 중복 확인 가능합니다.
- 닉네임 중복 확인의 경우 회원가입 시 json 형태의 ErrorResponse 로 넘어오기에 이를 처리하기 위해 `ErrorUtil` 을 만들었습니다. 닉네임 중복일 때의 statusCode인 409 인 경우 닉네임 중복에 대한 처리를 해주었습니다. [ [model에서의 사용법](https://github.com/A-APT/Duckdam-Android/blob/a11efa70fc4116ff46262ec396a36cda9487b34f/app/src/main/java/com/aligatorapt/duckdam/model/UserModel.kt#L33) ]

## 기타