### PR TITLE
Friend api

### DIFF
--- a/app/src/main/java/com/aligatorapt/duckdam/dto/compliment/ComplimentResponseDto.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/dto/compliment/ComplimentResponseDto.kt
@@ -5,8 +5,10 @@ import java.util.*
 
 data class ComplimentResponseDto (
     val fromId: Long,
+    val fromName: String,
     val toId: Long,
+    var toName: String,
     val stickerNum: Int,
     val message: String,
     val date: Date,
-): Serializable
+)

--- a/app/src/main/java/com/aligatorapt/duckdam/dto/user/LoginResponseDto.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/dto/user/LoginResponseDto.kt
@@ -2,5 +2,8 @@ package com.aligatorapt.duckdam.dto.user
 
 data class LoginResponseDto (
     val token: String,
-    val refreshToken: String
+    val refreshToken: String,
+    val uid: Long,
+    val name: String,
+    val profile: ByteArray?,
 )

--- a/app/src/main/java/com/aligatorapt/duckdam/dto/user/LoginResponseDto.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/dto/user/LoginResponseDto.kt
@@ -5,5 +5,5 @@ data class LoginResponseDto (
     val refreshToken: String,
     val uid: Long,
     val name: String,
-    val profile: ByteArray?,
+    val profile: ByteArray?
 )

--- a/app/src/main/java/com/aligatorapt/duckdam/dto/user/RegisterDto.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/dto/user/RegisterDto.kt
@@ -4,5 +4,5 @@ data class RegisterDto (
     val name: String,
     val password: String,
     val email: String,
-    val profile: String?
+    val profile: ByteArray?
 )

--- a/app/src/main/java/com/aligatorapt/duckdam/dto/user/UserResponseDto.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/dto/user/UserResponseDto.kt
@@ -1,7 +1,9 @@
 package com.aligatorapt.duckdam.dto.user
 
+import java.io.Serializable
+
 data class UserResponseDto (
     val uid: Long,
     val name: String,
     val profile: String?
-)
+): Serializable

--- a/app/src/main/java/com/aligatorapt/duckdam/model/FriendModel.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/model/FriendModel.kt
@@ -1,0 +1,64 @@
+package com.aligatorapt.duckdam.model
+
+import com.aligatorapt.duckdam.dto.user.UserResponseDto
+import com.aligatorapt.duckdam.retrofit.RetrofitClient
+import com.aligatorapt.duckdam.retrofit.callback.ApiCallback
+import com.aligatorapt.duckdam.retrofit.callback.UserCallback
+import com.aligatorapt.duckdam.sharedpreferences.MyApplication
+import okhttp3.ResponseBody
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
+import retrofit2.Retrofit
+
+object FriendModel {
+    fun followFriend(_targetId: Long, callback: ApiCallback){
+        val headers = HashMap<String, String>()
+        val userToken = MyApplication.prefs.getString("token", "notExist")
+        headers["Authorization"] = "Bearer $userToken"
+
+        RetrofitClient.FRIEND_INTERFACE_SERVICE.followFriend(
+            httpHeaders = headers,
+            targetId = _targetId
+        ).enqueue(object: Callback<ResponseBody>{
+            override fun onResponse(call: Call<ResponseBody>, response: Response<ResponseBody>) {
+                if(response.isSuccessful){
+                    callback.apiCallback(true)
+                }else{
+                    callback.apiCallback(false)
+                }
+            }
+
+            override fun onFailure(call: Call<ResponseBody>, t: Throwable) {
+                callback.apiCallback(false)
+            }
+
+        })
+    }
+
+    fun findMyFriend(callback: UserCallback){
+        val headers = HashMap<String, String>()
+        val userToken = MyApplication.prefs.getString("token", "notExist")
+        headers["Authorization"] = "Bearer $userToken"
+
+        RetrofitClient.FRIEND_INTERFACE_SERVICE.findMyFriends(
+            httpHeaders = headers
+        ).enqueue(object: Callback<ArrayList<UserResponseDto>>{
+            override fun onResponse(
+                call: Call<ArrayList<UserResponseDto>>,
+                response: Response<ArrayList<UserResponseDto>>
+            ) {
+                if(response.isSuccessful){
+                    callback.userCallback(true,response.body())
+                }else{
+                    callback.userCallback(false, null)
+                }
+            }
+
+            override fun onFailure(call: Call<ArrayList<UserResponseDto>>, t: Throwable) {
+                callback.userCallback(false, null)
+            }
+
+        })
+    }
+}

--- a/app/src/main/java/com/aligatorapt/duckdam/model/UserModel.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/model/UserModel.kt
@@ -5,15 +5,14 @@ import com.aligatorapt.duckdam.dto.user.LoginRequestDto
 import com.aligatorapt.duckdam.dto.user.LoginResponseDto
 import com.aligatorapt.duckdam.dto.user.RegisterDto
 import com.aligatorapt.duckdam.retrofit.RetrofitClient
-import com.aligatorapt.duckdam.retrofit.callback.ApiCallback
-import com.aligatorapt.duckdam.retrofit.callback.RegisterCallback
 import com.aligatorapt.duckdam.sharedpreferences.MyApplication
 import okhttp3.ResponseBody
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
 import com.aligatorapt.duckdam.dto.ErrorResponseDto
-import com.aligatorapt.duckdam.retrofit.callback.BooleanCallback
+import com.aligatorapt.duckdam.dto.user.UserResponseDto
+import com.aligatorapt.duckdam.retrofit.callback.*
 import com.aligatorapt.duckdam.sharedpreferences.ErrorUtil
 
 object UserModel{
@@ -82,6 +81,52 @@ object UserModel{
 
             override fun onFailure(call: Call<Boolean>, t: Throwable) {
                 callback.booleanCallback(false, null)
+            }
+        })
+    }
+
+    fun searchByName(_query: String, callback: UserListCallback){
+        val headers = HashMap<String, String>()
+        val userToken = MyApplication.prefs.getString("token", "notExist")
+        headers["Authorization"] = "Bearer $userToken"
+
+        RetrofitClient.USER_INTERFACE_SERVICE.searchByName(
+            httpHeaders = headers,
+            query = _query).enqueue(object :Callback<ArrayList<UserResponseDto>>{
+            override fun onResponse(call: Call<ArrayList<UserResponseDto>>, response: Response<ArrayList<UserResponseDto>>) {
+
+                Log.d("Response::", "Response::" + response.body().toString())
+                if(response.isSuccessful){
+                    callback.userListCallback(true, response.body())
+                }else{
+                    callback.userListCallback(false,null)
+                }
+            }
+
+            override fun onFailure(call: Call<ArrayList<UserResponseDto>>, t: Throwable) {
+                callback.userListCallback(false, null)
+            }
+        })
+    }
+
+    fun getStickerList(callback: BooleanListCallback){
+        val headers = HashMap<String, String>()
+        val userToken = MyApplication.prefs.getString("token", "notExist")
+        headers["Authorization"] = "Bearer $userToken"
+
+        RetrofitClient.USER_INTERFACE_SERVICE.getStickerList(httpHeaders = headers).enqueue(object: Callback<ArrayList<Boolean>>{
+            override fun onResponse(call: Call<ArrayList<Boolean>>, response: Response<ArrayList<Boolean>>) {
+
+                Log.d("Response::", "Response::" + response.body().toString())
+                if(response.isSuccessful){
+                    callback.booleanlistCallback(true, response.body())
+                }else{
+                    callback.booleanlistCallback(false, null)
+                }
+            }
+
+            override fun onFailure(call: Call<ArrayList<Boolean>>, t: Throwable) {
+                callback.booleanlistCallback(false, null)
             }
         })
     }

--- a/app/src/main/java/com/aligatorapt/duckdam/model/UserModel.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/model/UserModel.kt
@@ -1,5 +1,6 @@
 package com.aligatorapt.duckdam.model
 
+import android.util.Base64
 import android.util.Log
 import com.aligatorapt.duckdam.dto.user.LoginRequestDto
 import com.aligatorapt.duckdam.dto.user.LoginResponseDto
@@ -14,8 +15,11 @@ import com.aligatorapt.duckdam.dto.ErrorResponseDto
 import com.aligatorapt.duckdam.dto.user.UserResponseDto
 import com.aligatorapt.duckdam.retrofit.callback.*
 import com.aligatorapt.duckdam.sharedpreferences.ErrorUtil
+import com.aligatorapt.duckdam.viewModel.LoginSingleton
 
 object UserModel{
+    private val model = LoginSingleton.getInstance()
+
     fun register( _userInfo: RegisterDto, callback: RegisterCallback){
         RetrofitClient.USER_INTERFACE_SERVICE.register(_userInfo).enqueue(object: Callback<ResponseBody> {
             override fun onResponse(
@@ -51,6 +55,13 @@ object UserModel{
                 if(response.isSuccessful){
                     MyApplication.prefs.setString("token", response.body()!!.token)
                     MyApplication.prefs.setString("refreshToken", response.body()!!.refreshToken)
+                    val profile = Base64.encodeToString(response.body()!!.profile, Base64.DEFAULT)
+
+                    model?.setUser(UserResponseDto(
+                        uid = response.body()!!.uid,
+                        name = response.body()!!.name,
+                        profile = profile
+                    ))
                     callback.apiCallback(true)
                 }else{
                     callback.apiCallback(false)

--- a/app/src/main/java/com/aligatorapt/duckdam/model/UserModel.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/model/UserModel.kt
@@ -55,8 +55,10 @@ object UserModel{
                 if(response.isSuccessful){
                     MyApplication.prefs.setString("token", response.body()!!.token)
                     MyApplication.prefs.setString("refreshToken", response.body()!!.refreshToken)
-                    val profile = Base64.encodeToString(response.body()!!.profile, Base64.DEFAULT)
-
+                    var profile : String? = ""
+                    profile = if(response.body()!!.profile != null){
+                        Base64.encodeToString(response.body()!!.profile, Base64.DEFAULT)
+                    }else null
                     model?.setUser(UserResponseDto(
                         uid = response.body()!!.uid,
                         name = response.body()!!.name,

--- a/app/src/main/java/com/aligatorapt/duckdam/retrofit/RetrofitClient.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/retrofit/RetrofitClient.kt
@@ -9,9 +9,10 @@ import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import java.util.concurrent.TimeUnit
 import com.aligatorapt.duckdam.retrofit.`interface`.ComplimentInterface
+import com.aligatorapt.duckdam.retrofit.`interface`.FriendInterface
 
 object RetrofitClient {
-    private const val BASE_URL:String = "http://192.168.219.103:8080"
+    private const val BASE_URL:String = "http://172.30.1.28:8080"
 
     private val loggingInterceptor = HttpLoggingInterceptor()
 
@@ -43,4 +44,7 @@ object RetrofitClient {
         retrofit.create(ComplimentInterface::class.java)
     }
 
+    val FRIEND_INTERFACE_SERVICE: FriendInterface by lazy{
+        retrofit.create(FriendInterface::class.java)
+    }
 }

--- a/app/src/main/java/com/aligatorapt/duckdam/retrofit/callback/BooleanListCallback.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/retrofit/callback/BooleanListCallback.kt
@@ -1,0 +1,5 @@
+package com.aligatorapt.duckdam.retrofit.callback
+
+interface BooleanListCallback {
+    fun booleanlistCallback(flag: Boolean, data: ArrayList<Boolean>?)
+}

--- a/app/src/main/java/com/aligatorapt/duckdam/retrofit/callback/UserCallback.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/retrofit/callback/UserCallback.kt
@@ -1,0 +1,7 @@
+package com.aligatorapt.duckdam.retrofit.callback
+
+import com.aligatorapt.duckdam.dto.user.UserResponseDto
+
+interface UserCallback {
+    fun userCallback(flag: Boolean, data: ArrayList<UserResponseDto>?)
+}

--- a/app/src/main/java/com/aligatorapt/duckdam/retrofit/callback/UserListCallback.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/retrofit/callback/UserListCallback.kt
@@ -1,0 +1,7 @@
+package com.aligatorapt.duckdam.retrofit.callback
+
+import com.aligatorapt.duckdam.dto.user.UserResponseDto
+
+interface UserListCallback {
+    fun userListCallback(flag: Boolean, data: ArrayList<UserResponseDto>?)
+}

--- a/app/src/main/java/com/aligatorapt/duckdam/retrofit/interface/FriendInterface.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/retrofit/interface/FriendInterface.kt
@@ -1,0 +1,22 @@
+package com.aligatorapt.duckdam.retrofit.`interface`
+
+import com.aligatorapt.duckdam.dto.user.UserResponseDto
+import okhttp3.ResponseBody
+import retrofit2.Call
+import retrofit2.http.GET
+import retrofit2.http.HeaderMap
+import retrofit2.http.POST
+import retrofit2.http.Path
+
+interface FriendInterface {
+    @POST("/friend/follow/{targetId}")
+    fun followFriend(
+        @HeaderMap httpHeaders: Map<String, String>,
+        @Path("targetId") targetId: Long)
+    : Call<ResponseBody>
+
+    @GET("/friend")
+    fun findMyFriends(
+        @HeaderMap httpHeaders: Map<String, String>)
+    : Call<ArrayList<UserResponseDto>>
+}

--- a/app/src/main/java/com/aligatorapt/duckdam/retrofit/interface/UserInterface.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/retrofit/interface/UserInterface.kt
@@ -24,16 +24,16 @@ interface UserInterface {
         @Body refreshToken: String
     ): Call<LoginResponseDto>
 
-    @POST("/users/{query}")
+    @GET("/users/{query}")
     fun searchByName(
         @HeaderMap httpHeaders: HashMap<String, String>,
         @Path("query") query: String
-    ): Call<List<UserResponseDto>>
+    ): Call<ArrayList<UserResponseDto>>
 
-    @POST("/user/stickers")
+    @GET("/user/stickers")
     fun getStickerList(
         @HeaderMap httpHeaders: HashMap<String, String>
-    ): Call<List<Boolean>>
+    ): Call<ArrayList<Boolean>>
 
     @GET("/user/slot")
     fun isEligibleForSlot(

--- a/app/src/main/java/com/aligatorapt/duckdam/view/activity/FriendListDetailActivity.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/view/activity/FriendListDetailActivity.kt
@@ -1,19 +1,22 @@
 package com.aligatorapt.duckdam.view.activity
 
-import android.content.Intent
+import android.graphics.BitmapFactory
 import android.os.Bundle
+import android.util.Base64
+import android.view.View
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.content.ContentProviderCompat.requireContext
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.aligatorapt.duckdam.R
 import com.aligatorapt.duckdam.databinding.ActivityFriendlistDetailBinding
+import com.aligatorapt.duckdam.dto.compliment.ComplimentResponseDto
+import com.aligatorapt.duckdam.dto.user.UserResponseDto
+import com.aligatorapt.duckdam.retrofit.callback.ComplimentsCallback
 import com.aligatorapt.duckdam.view.adapter.FriendListDetailAdapter
-import com.aligatorapt.duckdam.view.data.AllComplimentChild
-import com.aligatorapt.duckdam.view.data.SelectList
-import com.aligatorapt.duckdam.view.fragment.compliment.ComplimentFragment
+import com.aligatorapt.duckdam.viewModel.ComplimentSingleton
 
 class FriendListDetailActivity: AppCompatActivity() {
     lateinit var binding: ActivityFriendlistDetailBinding
+    private val model = ComplimentSingleton.getInstance()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -25,85 +28,53 @@ class FriendListDetailActivity: AppCompatActivity() {
 
     private fun init(){
         //친구 이름으로 칭찬내역 찾기
-        val selectList = intent.getSerializableExtra("data") as SelectList
+        val friend = intent.getSerializableExtra("data") as UserResponseDto
 
         binding.apply {
-            fldetailName.text = selectList.name
-            fldetailSticker.setImageResource(selectList.sticker)
             val linearLayoutManager = LinearLayoutManager(applicationContext)
             linearLayoutManager.orientation = LinearLayoutManager.VERTICAL
             fldetailRv.layoutManager = linearLayoutManager
-            val friendListDetailAdapter = FriendListDetailAdapter(applicationContext, setList())
+            val friendListDetailAdapter = FriendListDetailAdapter(applicationContext, arrayListOf())
             fldetailRv.adapter = friendListDetailAdapter
+
+            fldetailName.text = friend.name
+            if(friend.profile != null){
+                val decodedImageBytes: ByteArray = Base64.decode(friend.profile, Base64.DEFAULT)
+                val bitmap = BitmapFactory.decodeByteArray(decodedImageBytes, 0, decodedImageBytes.size)
+                fldetailSticker.setImageBitmap(bitmap)
+            }else {
+                fldetailSticker.setImageResource(R.drawable.small_sample)
+            }
+
+            model?.findComplimentsByFromAndTo(
+                _toId = friend.uid,
+                object: ComplimentsCallback{
+                    override fun complimentsCallback(
+                        flag: Boolean,
+                        data: ArrayList<ComplimentResponseDto>?
+                    ) {
+                        if(flag){
+                            if(data!!.isNotEmpty()){
+                                emptyResult.visibility = View.GONE
+                                fldetailRv.visibility = View.VISIBLE
+                                friendListDetailAdapter.setData(data)
+                            }else{
+                                emptyResult.visibility = View.VISIBLE
+                                fldetailRv.visibility = View.GONE
+
+                            }
+                        }
+                    }
+            })
 
             fldetailBackTv.setOnClickListener {
                 finish()
             }
             fldetailCompliment.setOnClickListener {
-                intent.putExtra("selectList",selectList)
                 setResult(RESULT_OK,intent)
                 finish()
             }
         }
 
-    }
-
-    private fun setList(): ArrayList<AllComplimentChild> {
-        return arrayListOf(
-            AllComplimentChild(
-                sticker = R.drawable.sticker06,
-                date = "2022.01.02",
-                content = "오늘 하루 도움을 줘서 너무 고마워! 네가 없었으면 우리 팀은 이기지 못했을 거야 :)",
-                from = "어깨피자"
-            ),
-            AllComplimentChild(
-                sticker = R.drawable.sticker07,
-                date = "2022.01.02",
-                content = "너무 고마운데 이걸 말로 어떻게 길게 표현하지 세상에서 제일 긴 말로 너를 칭찬하고 싶은데 이정도면 될까?",
-                from = "어깨피자"
-            ),
-            AllComplimentChild(
-                sticker = R.drawable.sticker08,
-                date = "2022.01.20",
-                content = "세상에서 제일 긴 말로 너를 칭찬하고 싶은데 이정도면 될까?",
-                from = "어깨피자"
-            ),
-            AllComplimentChild(
-                sticker = R.drawable.sticker06,
-                date = "2022.01.02",
-                content = "오늘 하루 도움을 줘서 너무 고마워! 네가 없었으면 우리 팀은 이기지 못했을 거야 :)",
-                from = "어깨피자"
-            ),
-            AllComplimentChild(
-                sticker = R.drawable.sticker07,
-                date = "2022.01.02",
-                content = "너무 고마운데 이걸 말로 어떻게 길게 표현하지 세상에서 제일 긴 말로 너를 칭찬하고 싶은데 이정도면 될까?",
-                from = "어깨피자"
-            ),
-            AllComplimentChild(
-                sticker = R.drawable.sticker08,
-                date = "2022.01.20",
-                content = "세상에서 제일 긴 말로 너를 칭찬하고 싶은데 이정도면 될까?",
-                from = "어깨피자"
-            ),
-            AllComplimentChild(
-                sticker = R.drawable.sticker06,
-                date = "2022.01.02",
-                content = "오늘 하루 도움을 줘서 너무 고마워! 네가 없었으면 우리 팀은 이기지 못했을 거야 :)",
-                from = "어깨피자"
-            ),
-            AllComplimentChild(
-                sticker = R.drawable.sticker07,
-                date = "2022.01.02",
-                content = "너무 고마운데 이걸 말로 어떻게 길게 표현하지 세상에서 제일 긴 말로 너를 칭찬하고 싶은데 이정도면 될까?",
-                from = "어깨피자"
-            ),
-            AllComplimentChild(
-                sticker = R.drawable.sticker08,
-                date = "2022.01.20",
-                content = "세상에서 제일 긴 말로 너를 칭찬하고 싶은데 이정도면 될까?",
-                from = "어깨피자"
-            ),
-        )
     }
 }

--- a/app/src/main/java/com/aligatorapt/duckdam/view/activity/SignUpActivity.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/view/activity/SignUpActivity.kt
@@ -6,7 +6,6 @@ import android.graphics.ImageDecoder
 import android.os.Build
 import android.os.Bundle
 import android.provider.MediaStore
-import android.util.Base64
 import android.util.Log
 import android.view.View
 import android.widget.Toast
@@ -147,7 +146,7 @@ class SignUpActivity: AppCompatActivity() {
                             name = signupNickname.text.toString(),
                             password = signupPwEt.text.toString(),
                             email = model.email.value.toString(),
-                            profile = ByteArray(1)
+                            profile = model.profile.value
                         ), object : RegisterCallback {
                             override fun registerCallback(flag: Boolean, isNickname: Boolean) {
                                 if (flag) {

--- a/app/src/main/java/com/aligatorapt/duckdam/view/activity/SignUpActivity.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/view/activity/SignUpActivity.kt
@@ -1,10 +1,12 @@
 package com.aligatorapt.duckdam.view.activity
 
 import android.content.Intent
+import android.graphics.Bitmap
 import android.graphics.ImageDecoder
 import android.os.Build
 import android.os.Bundle
 import android.provider.MediaStore
+import android.util.Base64
 import android.util.Log
 import android.view.View
 import android.widget.Toast
@@ -12,16 +14,14 @@ import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.core.widget.doAfterTextChanged
-import androidx.fragment.app.activityViewModels
-import androidx.lifecycle.Observer
 import com.aligatorapt.duckdam.R
 import com.aligatorapt.duckdam.databinding.ActivitySignupBinding
 import com.aligatorapt.duckdam.dto.auth.EmailTokenDto
 import com.aligatorapt.duckdam.dto.user.RegisterDto
-import com.aligatorapt.duckdam.model.UserModel.register
 import com.aligatorapt.duckdam.retrofit.callback.ApiCallback
 import com.aligatorapt.duckdam.retrofit.callback.RegisterCallback
 import com.aligatorapt.duckdam.viewModel.RegisterViewModel
+import java.io.ByteArrayOutputStream
 import java.lang.Exception
 import java.util.regex.Pattern
 
@@ -177,7 +177,11 @@ class SignUpActivity: AppCompatActivity() {
                     currentImageUri?.let {
                         if (Build.VERSION.SDK_INT < 28) {
                             val bitmap = MediaStore.Images.Media.getBitmap(contentResolver, currentImageUri)
-                            model.setProfile(bitmap.toString())
+                            val profileByteArray = ByteArrayOutputStream()
+                            bitmap.compress(Bitmap.CompressFormat.PNG, 2, profileByteArray)
+                            val byte_data = profileByteArray.toByteArray()
+
+                            model.setProfile(Base64.encodeToString(byte_data, Base64.DEFAULT))
                             binding.signupImage.setImageBitmap(bitmap)
                             //string -> bytearray
                             // bytearray.contentToString()

--- a/app/src/main/java/com/aligatorapt/duckdam/view/activity/SignUpActivity.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/view/activity/SignUpActivity.kt
@@ -147,7 +147,7 @@ class SignUpActivity: AppCompatActivity() {
                             name = signupNickname.text.toString(),
                             password = signupPwEt.text.toString(),
                             email = model.email.value.toString(),
-                            profile = model.profile.value
+                            profile = ByteArray(1)
                         ), object : RegisterCallback {
                             override fun registerCallback(flag: Boolean, isNickname: Boolean) {
                                 if (flag) {
@@ -177,18 +177,22 @@ class SignUpActivity: AppCompatActivity() {
                     currentImageUri?.let {
                         if (Build.VERSION.SDK_INT < 28) {
                             val bitmap = MediaStore.Images.Media.getBitmap(contentResolver, currentImageUri)
-                            val profileByteArray = ByteArrayOutputStream()
+                            val profileByteArray: ByteArrayOutputStream? = ByteArrayOutputStream()
                             bitmap.compress(Bitmap.CompressFormat.PNG, 2, profileByteArray)
-                            val byte_data = profileByteArray.toByteArray()
-
-                            model.setProfile(Base64.encodeToString(byte_data, Base64.DEFAULT))
+                            if(profileByteArray != null){
+                                val bytes = profileByteArray.toByteArray()
+                                model.setProfile(bytes)
+                            }
                             binding.signupImage.setImageBitmap(bitmap)
-                            //string -> bytearray
-                            // bytearray.contentToString()
                         } else {
                             val source = ImageDecoder.createSource(contentResolver, currentImageUri)
                             val bitmap = ImageDecoder.decodeBitmap(source)
-                            model.setProfile(bitmap.toString())
+                            val profileByteArray: ByteArrayOutputStream? = ByteArrayOutputStream()
+                            bitmap.compress(Bitmap.CompressFormat.PNG, 2, profileByteArray)
+                            if(profileByteArray != null){
+                                val bytes = profileByteArray.toByteArray()
+                                model.setProfile(bytes)
+                            }
                             binding.signupImage.setImageBitmap(bitmap)
                         }
                     }

--- a/app/src/main/java/com/aligatorapt/duckdam/view/adapter/FriendListAdapter.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/view/adapter/FriendListAdapter.kt
@@ -3,7 +3,6 @@ package com.aligatorapt.duckdam.view.adapter
 import android.content.Context
 import android.graphics.BitmapFactory
 import android.util.Base64
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -16,7 +15,8 @@ import com.aligatorapt.duckdam.viewModel.FriendViewModel
 class FriendListAdapter(
     val context: Context,
     var items: ArrayList<UserResponseDto>,
-    val viewModel: FriendViewModel?
+    val viewModel: FriendViewModel?,
+    val user: UserResponseDto?
 ) : RecyclerView.Adapter<FriendListAdapter.MyViewHolder>(){
 
     var isFriendPage: Boolean = true
@@ -46,7 +46,9 @@ class FriendListAdapter(
                 if (viewModel != null) {
                     if(viewModel.friends.value != null && viewModel.friends.value!!.contains(items[position])) {
                         rowAdd.visibility = View.GONE
-                    }else {
+                    } else if(viewModel.friends.value!!.contains(user)){    // TODO 자기 자신 잘 걸러지는지 확인
+                        rowAdd.visibility = View.GONE
+                    } else {
                         rowAdd.visibility = View.VISIBLE
                     }
                 }

--- a/app/src/main/java/com/aligatorapt/duckdam/view/adapter/FriendListAdapter.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/view/adapter/FriendListAdapter.kt
@@ -1,0 +1,79 @@
+package com.aligatorapt.duckdam.view.adapter
+
+import android.content.Context
+import android.graphics.BitmapFactory
+import android.util.Base64
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.aligatorapt.duckdam.R
+import com.aligatorapt.duckdam.databinding.RowFriendlistBinding
+import com.aligatorapt.duckdam.dto.user.UserResponseDto
+import com.aligatorapt.duckdam.viewModel.FriendViewModel
+
+class FriendListAdapter(
+    val context: Context,
+    var items: ArrayList<UserResponseDto>,
+    val viewModel: FriendViewModel?
+) : RecyclerView.Adapter<FriendListAdapter.MyViewHolder>(){
+
+    var isFriendPage: Boolean = true
+
+    interface OnItemClickListener{
+        fun OnItemClick(data: UserResponseDto, position: Int)
+        fun OnAddClick(data: UserResponseDto, position: Int)
+    }
+
+    var itemClickListener: OnItemClickListener ?= null
+
+    fun setData(newData: ArrayList<UserResponseDto>, _isFriendPage: Boolean){
+        items.clear()
+        items.addAll(newData)
+        isFriendPage = _isFriendPage
+        notifyDataSetChanged()
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MyViewHolder {
+        val view = RowFriendlistBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return MyViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: MyViewHolder, position: Int) {
+        holder.binding.apply {
+            if(!isFriendPage){
+                if (viewModel != null) {
+                    if(viewModel.friends.value != null && viewModel.friends.value!!.contains(items[position])) {
+                        rowAdd.visibility = View.GONE
+                    }else {
+                        rowAdd.visibility = View.VISIBLE
+                    }
+                }
+            }else rowAdd.visibility = View.GONE
+            if(position == 0) rowView.visibility = View.GONE
+
+            if(items[position].profile != null){
+                val decodedImageBytes: ByteArray = Base64.decode(items[position].profile, Base64.DEFAULT)
+                val bitmap = BitmapFactory.decodeByteArray(decodedImageBytes, 0, decodedImageBytes.size)
+                rowSticker.setImageBitmap(bitmap)
+            }else {
+                rowSticker.setImageResource(R.drawable.small_sample)
+            }
+            rowName.text = items[position].name
+
+            rowLayout.setOnClickListener {
+                itemClickListener?.OnItemClick(items[position], position)
+            }
+            rowAdd.setOnClickListener {
+                rowAdd.visibility = View.GONE
+                itemClickListener?.OnAddClick(items[position], position)
+            }
+        }
+    }
+
+    override fun getItemCount(): Int = items.size
+
+    inner class MyViewHolder(val binding: RowFriendlistBinding): RecyclerView.ViewHolder(binding.root) {
+    }
+}

--- a/app/src/main/java/com/aligatorapt/duckdam/view/adapter/FriendListAdapter.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/view/adapter/FriendListAdapter.kt
@@ -19,7 +19,7 @@ class FriendListAdapter(
     val user: UserResponseDto?
 ) : RecyclerView.Adapter<FriendListAdapter.MyViewHolder>(){
 
-    var isFriendPage: Boolean = true
+    var isFriendPage: Boolean = false
 
     interface OnItemClickListener{
         fun OnItemClick(data: UserResponseDto, position: Int)
@@ -46,14 +46,13 @@ class FriendListAdapter(
                 if (viewModel != null) {
                     if(viewModel.friends.value != null && viewModel.friends.value!!.contains(items[position])) {
                         rowAdd.visibility = View.GONE
-                    } else if(viewModel.friends.value!!.contains(user)){    // TODO 자기 자신 잘 걸러지는지 확인
+                    } else if(items[position] == user){
                         rowAdd.visibility = View.GONE
                     } else {
                         rowAdd.visibility = View.VISIBLE
                     }
                 }
             }else rowAdd.visibility = View.GONE
-            if(position == 0) rowView.visibility = View.GONE
 
             if(items[position].profile != null){
                 val decodedImageBytes: ByteArray = Base64.decode(items[position].profile, Base64.DEFAULT)
@@ -64,18 +63,20 @@ class FriendListAdapter(
             }
             rowName.text = items[position].name
 
-            rowLayout.setOnClickListener {
-                itemClickListener?.OnItemClick(items[position], position)
-            }
-            rowAdd.setOnClickListener {
-                rowAdd.visibility = View.GONE
-                itemClickListener?.OnAddClick(items[position], position)
-            }
         }
     }
 
     override fun getItemCount(): Int = items.size
 
     inner class MyViewHolder(val binding: RowFriendlistBinding): RecyclerView.ViewHolder(binding.root) {
+        init {
+            binding.rowLayout.setOnClickListener {
+                itemClickListener?.OnItemClick(items[adapterPosition], adapterPosition)
+            }
+            binding.rowAdd.setOnClickListener {
+                binding.rowAdd.visibility = View.GONE
+                itemClickListener?.OnAddClick(items[adapterPosition], adapterPosition)
+            }
+        }
     }
 }

--- a/app/src/main/java/com/aligatorapt/duckdam/view/adapter/FriendListDetailAdapter.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/view/adapter/FriendListDetailAdapter.kt
@@ -4,11 +4,21 @@ import android.content.Context
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
+import com.aligatorapt.duckdam.R
 import com.aligatorapt.duckdam.databinding.RowFriendlistdetailBinding
+import com.aligatorapt.duckdam.dto.compliment.ComplimentResponseDto
+import com.aligatorapt.duckdam.dto.user.UserResponseDto
 import com.aligatorapt.duckdam.view.data.AllComplimentChild
+import java.text.SimpleDateFormat
 
-class FriendListDetailAdapter(val context: Context, var items: ArrayList<AllComplimentChild>)
+class FriendListDetailAdapter(val context: Context, var items: ArrayList<ComplimentResponseDto>)
     :RecyclerView.Adapter<FriendListDetailAdapter.MyViewHolder>(){
+
+    fun setData(newData:ArrayList<ComplimentResponseDto>){
+        items.clear()
+        items.addAll(newData)
+        notifyDataSetChanged()
+    }
 
     override fun onCreateViewHolder(
         parent: ViewGroup,
@@ -19,10 +29,10 @@ class FriendListDetailAdapter(val context: Context, var items: ArrayList<AllComp
     }
 
     override fun onBindViewHolder(holder: FriendListDetailAdapter.MyViewHolder, position: Int) {
-        holder.binding.apply {
-            rowFldetailSticker.setImageResource(items[position].sticker)
-            rowFldetailDate.text = items[position].date
-            rowFldetailContent.text = items[position].content
+        holder.binding.apply { rowFldetailSticker.setImageResource(context.resources.obtainTypedArray(R.array.stickerImg).getResourceId(items[position].stickerNum, 0))
+            val dateFormat = SimpleDateFormat("yyyy.MM.dd")
+            rowFldetailDate.text = dateFormat.format(items[position].date)
+            rowFldetailContent.text = items[position].message
         }
     }
 

--- a/app/src/main/java/com/aligatorapt/duckdam/view/adapter/SelectListAdapter.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/view/adapter/SelectListAdapter.kt
@@ -1,27 +1,34 @@
 package com.aligatorapt.duckdam.view.adapter
 
+import android.annotation.SuppressLint
 import android.content.Context
+import android.graphics.BitmapFactory
+import android.util.Base64
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
+import com.aligatorapt.duckdam.R
 import com.aligatorapt.duckdam.databinding.RowDialogBinding
-import com.aligatorapt.duckdam.view.data.AllComplimentChild
-import com.aligatorapt.duckdam.view.data.SelectList
+import com.aligatorapt.duckdam.dto.compliment.ComplimentResponseDto
+import com.aligatorapt.duckdam.dto.user.UserResponseDto
 
-class SelectListAdapter (val context: Context, var items: ArrayList<SelectList>, val isFriendPage: Boolean)
-    : RecyclerView.Adapter<SelectListAdapter.MyViewHolder>(){
+class SelectListAdapter (
+    val context: Context,
+    var items: ArrayList<UserResponseDto>
+    ) : RecyclerView.Adapter<SelectListAdapter.MyViewHolder>(){
 
+    private var isSticker: Boolean = false
     interface OnItemClickListener{
-        fun OnItemClick(data: SelectList, position: Int)
-        fun OnAddClick(data: SelectList, position: Int)
+        fun OnItemClick(data: UserResponseDto, position: Int, isSticker: Boolean)
     }
 
     var itemClickListener: OnItemClickListener ?= null
 
-    fun setData(newData:ArrayList<SelectList>){
+    fun setData(newData:ArrayList<UserResponseDto>, _isSticker: Boolean){
         items.clear()
         items.addAll(newData)
+        isSticker = _isSticker
         notifyDataSetChanged()
     }
 
@@ -30,31 +37,34 @@ class SelectListAdapter (val context: Context, var items: ArrayList<SelectList>,
         return MyViewHolder(view)
     }
 
+    @SuppressLint("ResourceType")
     override fun onBindViewHolder(holder: SelectListAdapter.MyViewHolder, position: Int) {
         holder.binding.apply {
-            if(isFriendPage && !items[position].isAdded){
-                rowAdd.visibility = View.VISIBLE
-            }else {
-                rowAdd.visibility = View.GONE
-            }
             if(position == 0) rowView.visibility = View.GONE
-            rowSticker.setImageResource(items[position].sticker)
-            rowName.text = items[position].name
+
+            if(!isSticker){
+                if(items[position].profile != null){
+                    val decodedImageBytes: ByteArray = Base64.decode(items[position].profile, Base64.DEFAULT)
+                    val bitmap = BitmapFactory.decodeByteArray(decodedImageBytes, 0, decodedImageBytes.size)
+                    rowSticker.setImageBitmap(bitmap)
+                }else {
+                    rowSticker.setImageResource(R.drawable.small_sample)
+                }
+                rowName.text = items[position].name
+            }else{
+                rowSticker.setImageResource(context.resources.obtainTypedArray(R.array.stickerImg).getResourceId(items[position].profile!!.toInt(), 0))
+                rowName.text = items[position].name
+            }
+
+            rowLayout.setOnClickListener{
+                itemClickListener?.OnItemClick(items[position], position, isSticker)
+            }
         }
     }
 
     override fun getItemCount(): Int = items.size
 
     inner class MyViewHolder(val binding: RowDialogBinding): RecyclerView.ViewHolder(binding.root){
-        init {
-            binding.rowLayout.setOnClickListener{
-                itemClickListener?.OnItemClick(items[adapterPosition], adapterPosition)
-            }
-            binding.rowAdd.setOnClickListener {
-                binding.rowAdd.visibility = View.GONE
-                itemClickListener?.OnAddClick(items[adapterPosition], adapterPosition)
-            }
-        }
     }
 
 }

--- a/app/src/main/java/com/aligatorapt/duckdam/view/adapter/StickerAdapter.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/view/adapter/StickerAdapter.kt
@@ -1,19 +1,27 @@
 package com.aligatorapt.duckdam.view.adapter
 
 import android.content.Context
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.core.view.setPadding
 import androidx.recyclerview.widget.RecyclerView
 import com.aligatorapt.duckdam.R
 import com.aligatorapt.duckdam.databinding.RowStickerBinding
-import com.aligatorapt.duckdam.view.data.SelectList
 
-
-
-
-class StickerAdapter(val context: Context, var items: ArrayList<SelectList>)
+class StickerAdapter(
+    val context: Context,
+    var items: ArrayList<Boolean>,
+    var stringArray: Array<String>
+)
     : RecyclerView.Adapter<StickerAdapter.MyViewHolder>(){
+
+    fun setData(newData:ArrayList<Boolean>){
+        items.clear()
+        items.addAll(newData)
+        notifyDataSetChanged()
+    }
+
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): StickerAdapter.MyViewHolder {
         val view = RowStickerBinding.inflate(LayoutInflater.from(parent.context),parent,false)
         return MyViewHolder(view)
@@ -21,9 +29,9 @@ class StickerAdapter(val context: Context, var items: ArrayList<SelectList>)
 
     override fun onBindViewHolder(holder: StickerAdapter.MyViewHolder, position: Int) {
         holder.binding.apply {
-            if(items[position].isAdded){
-                rowStickerSticker.setImageResource(items[position].sticker)
-                rowStickerName.text = items[position].name
+            if(items[position]){
+                rowStickerSticker.setImageResource(context.resources.obtainTypedArray(R.array.stickerImg).getResourceId(position, 0))
+                rowStickerName.text = stringArray[position]
             }else{
                 rowStickerSticker.setImageResource(R.drawable.small_sample)
                 rowStickerSticker.setPadding(12)

--- a/app/src/main/java/com/aligatorapt/duckdam/view/data/SelectList.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/view/data/SelectList.kt
@@ -1,9 +1,0 @@
-package com.aligatorapt.duckdam.view.data
-
-import java.io.Serializable
-
-data class SelectList (
-    var sticker : Int,
-    var name : String,
-    var isAdded : Boolean
-): Serializable

--- a/app/src/main/java/com/aligatorapt/duckdam/view/fragment/compliment/ComplimentDetailFragment.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/view/fragment/compliment/ComplimentDetailFragment.kt
@@ -49,9 +49,9 @@ class ComplimentDetailFragment : Fragment() {
                     )
                     date.text = dateFormat.format(it.date)
                     content.text = it.message
-                    from.text = "${it.fromId}가" //Todo change nickname
-                    complimentBtn.text = "${it.fromId}에게 칭찬하러 가기"
-                    addFriendBtn.text = "${it.fromId} 친구 추가하기"
+                    from.text = "${it.fromName}가"
+                    complimentBtn.text = "${it.fromName}에게 칭찬하러 가기"
+                    addFriendBtn.text = "${it.fromName} 친구 추가하기"
                 }
             })
 

--- a/app/src/main/java/com/aligatorapt/duckdam/view/fragment/compliment/FriendListFragment.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/view/fragment/compliment/FriendListFragment.kt
@@ -20,6 +20,7 @@ import com.aligatorapt.duckdam.retrofit.callback.UserCallback
 import com.aligatorapt.duckdam.retrofit.callback.UserListCallback
 import com.aligatorapt.duckdam.view.adapter.FriendListAdapter
 import com.aligatorapt.duckdam.viewModel.FriendSingleton
+import com.aligatorapt.duckdam.viewModel.LoginSingleton
 
 class FriendListFragment : Fragment() {
     private var _binding: FragmentFriendlistBinding? = null
@@ -27,6 +28,7 @@ class FriendListFragment : Fragment() {
     private val DETAIL = 100
 
     private val friendmodel = FriendSingleton.getInstance()
+    private val usermodel = LoginSingleton.getInstance()
     lateinit var selectFriend: UserResponseDto
 
     override fun onCreateView(
@@ -48,7 +50,8 @@ class FriendListFragment : Fragment() {
             val linearLayoutManager = LinearLayoutManager(requireContext())
             linearLayoutManager.orientation = LinearLayoutManager.VERTICAL
             friendlistRv.layoutManager = linearLayoutManager
-            val selectAdapter = FriendListAdapter(requireContext(), arrayListOf(),friendmodel)
+            val user = usermodel?.user!!.value
+            val selectAdapter = FriendListAdapter(requireContext(), arrayListOf(),friendmodel, user)
 
             selectAdapter.itemClickListener = object: FriendListAdapter.OnItemClickListener{
                 override fun OnItemClick(data: UserResponseDto, position: Int) {

--- a/app/src/main/java/com/aligatorapt/duckdam/view/fragment/compliment/FriendListFragment.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/view/fragment/compliment/FriendListFragment.kt
@@ -30,6 +30,7 @@ class FriendListFragment : Fragment() {
     private val friendmodel = FriendSingleton.getInstance()
     private val usermodel = LoginSingleton.getInstance()
     lateinit var selectFriend: UserResponseDto
+    lateinit var selectAdapter: FriendListAdapter
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -51,7 +52,7 @@ class FriendListFragment : Fragment() {
             linearLayoutManager.orientation = LinearLayoutManager.VERTICAL
             friendlistRv.layoutManager = linearLayoutManager
             val user = usermodel?.user!!.value
-            val selectAdapter = FriendListAdapter(requireContext(), arrayListOf(),friendmodel, user)
+            selectAdapter = FriendListAdapter(requireContext(), arrayListOf(),friendmodel, user)
 
             selectAdapter.itemClickListener = object: FriendListAdapter.OnItemClickListener{
                 override fun OnItemClick(data: UserResponseDto, position: Int) {
@@ -66,6 +67,7 @@ class FriendListFragment : Fragment() {
                         object: ApiCallback{
                             override fun apiCallback(flag: Boolean) {
                                 if(flag){
+                                    findMyFrined()
                                     Toast.makeText(requireContext(),"친구로 추가되었습니다!",Toast.LENGTH_SHORT).show()
                                 }
                             }
@@ -78,12 +80,12 @@ class FriendListFragment : Fragment() {
                 override fun userCallback(flag: Boolean, data: ArrayList<UserResponseDto>?) {
                     if(flag){
                         if(data!!.isNotEmpty()){
-                            friendmodel.setFriend(data)
-                            selectAdapter.setData(data,true)
+                            emptyResult.visibility = View.GONE
                         }else{
                             emptyResult.visibility = View.VISIBLE
-                            friendlistRv.visibility = View.GONE
                         }
+                        friendmodel.setFriend(data)
+                        selectAdapter.setData(data,true)
                         friendnum.text = data.size.toString()
                     }
                 }
@@ -102,15 +104,13 @@ class FriendListFragment : Fragment() {
                         if(flag){
                             if(data!!.isNotEmpty()){
                                 emptyResult.visibility = View.GONE
-                                friendlistRv.visibility - View.VISIBLE
-                                selectAdapter.setData(data, false)
                             }
                             else{
                                 emptyResult.visibility = View.VISIBLE
                                 textView.text = "검색된 친구가 없어요"
                                 textView2.visibility = View.GONE
-                                friendlistRv.visibility = View.GONE
                             }
+                            selectAdapter.setData(data, false)
                         }
                     }
                 })
@@ -118,9 +118,21 @@ class FriendListFragment : Fragment() {
         }
     }
 
+    private fun findMyFrined(){
+        binding.apply {
+            friendmodel?.findMyFriend(object: UserCallback{
+                override fun userCallback(flag: Boolean, data: ArrayList<UserResponseDto>?) {
+                    if(flag){
+                        friendmodel.setFriend(data)
+                        friendnum.text = data!!.size.toString()
+                    }
+                }
+            })
+        }
+    }
+
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
-
         if(resultCode == RESULT_OK){
             val mActivity = activity as NavigationActivity
             val bundle = Bundle()

--- a/app/src/main/java/com/aligatorapt/duckdam/view/fragment/home/ScrollHorizontalFragment.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/view/fragment/home/ScrollHorizontalFragment.kt
@@ -143,7 +143,7 @@ class ScrollHorizontalFragment : Fragment() {
     private fun setContent(item: ComplimentResponseDto){
         binding.apply {
             content.text = item.message
-            nickname.text = item.fromId.toString()  //Todo change nickname
+            nickname.text = item.fromName
         }
     }
 

--- a/app/src/main/java/com/aligatorapt/duckdam/view/fragment/home/ScrollHorizontalFragment.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/view/fragment/home/ScrollHorizontalFragment.kt
@@ -11,12 +11,15 @@ import androidx.fragment.app.Fragment
 import androidx.viewpager2.widget.ViewPager2
 import com.aligatorapt.duckdam.databinding.FragmentScrollHorizontalBinding
 import com.aligatorapt.duckdam.dto.compliment.ComplimentResponseDto
+import com.aligatorapt.duckdam.dto.user.UserResponseDto
 import com.aligatorapt.duckdam.retrofit.callback.ComplimentsCallback
+import com.aligatorapt.duckdam.retrofit.callback.UserCallback
 import com.aligatorapt.duckdam.view.activity.NavigationActivity
 import com.aligatorapt.duckdam.view.activity.VendingActivity
 import com.aligatorapt.duckdam.view.adapter.HomeStickerAdapter
 import com.aligatorapt.duckdam.view.fragment.compliment.ComplimentDetailFragment
 import com.aligatorapt.duckdam.viewModel.ComplimentSingleton
+import com.aligatorapt.duckdam.viewModel.FriendSingleton
 import java.text.SimpleDateFormat
 import java.util.*
 import kotlin.collections.ArrayList
@@ -28,6 +31,7 @@ class ScrollHorizontalFragment : Fragment() {
     private lateinit var complimentAdapter: HomeStickerAdapter
 
     private val model = ComplimentSingleton.getInstance()
+    private val friendmodel = FriendSingleton.getInstance()
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -96,6 +100,17 @@ class ScrollHorizontalFragment : Fragment() {
                                 showCompliment.visibility = View.GONE
                                 emptyResult.visibility = View.VISIBLE
                             }
+                        }
+                    }
+                }
+            })
+
+            //친구 목록 가져오기
+            friendmodel?.findMyFriend(object: UserCallback {
+                override fun userCallback(flag: Boolean, data: ArrayList<UserResponseDto>?) {
+                    if(flag){
+                        if(data!!.isNotEmpty()){
+                            friendmodel.setFriend(data)
                         }
                     }
                 }

--- a/app/src/main/java/com/aligatorapt/duckdam/view/fragment/setting/SettingFragment.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/view/fragment/setting/SettingFragment.kt
@@ -1,16 +1,21 @@
 package com.aligatorapt.duckdam.view.fragment.setting
 
+import android.graphics.BitmapFactory
 import android.os.Bundle
+import android.util.Base64
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import com.aligatorapt.duckdam.databinding.FragmentSettingBinding
+import com.aligatorapt.duckdam.sharedpreferences.MyApplication
+import com.aligatorapt.duckdam.viewModel.LoginSingleton
 
 class SettingFragment : Fragment() {
     private var _binding: FragmentSettingBinding? = null
     private val binding: FragmentSettingBinding get() = _binding!!
 
+    private val model = LoginSingleton.getInstance()
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
@@ -25,7 +30,15 @@ class SettingFragment : Fragment() {
     }
 
     private fun init(){
-
+        binding.apply {
+            if(model!!.user.value!!.profile != null){
+                val decodedImageBytes: ByteArray = Base64.decode(model.user.value!!.profile, Base64.DEFAULT)
+                val bitmap = BitmapFactory.decodeByteArray(decodedImageBytes, 0, decodedImageBytes.size)
+                sticker.setImageBitmap(bitmap)
+            }
+            rowStickerName.text = model.user.value!!.name
+            settingEmail.text = MyApplication.prefs.getString("email", "notExist")
+        }
     }
 
     override fun onDestroy() {

--- a/app/src/main/java/com/aligatorapt/duckdam/view/fragment/sticker/StickerFragment.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/view/fragment/sticker/StickerFragment.kt
@@ -8,12 +8,15 @@ import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.GridLayoutManager
 import com.aligatorapt.duckdam.R
 import com.aligatorapt.duckdam.databinding.FragmentStickerBinding
+import com.aligatorapt.duckdam.retrofit.callback.BooleanListCallback
 import com.aligatorapt.duckdam.view.adapter.StickerAdapter
-import com.aligatorapt.duckdam.view.data.SelectList
+import com.aligatorapt.duckdam.viewModel.StickerSingleton
 
 class StickerFragment : Fragment() {
     private var _binding: FragmentStickerBinding? = null
     private val binding: FragmentStickerBinding get() = _binding!!
+
+    private val stickermodel = StickerSingleton.getInstance()
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -30,11 +33,22 @@ class StickerFragment : Fragment() {
 
     private fun init(){
         binding.apply {
+            var list : ArrayList<Int> = arrayListOf()
+
             val gridLayoutManger = GridLayoutManager(requireContext(),2)
             gridLayoutManger.orientation = GridLayoutManager.VERTICAL
             stickerRv.layoutManager = gridLayoutManger
-            val stickerAdapter = StickerAdapter(requireContext(), setStickerList())
+            val stickerAdapter = StickerAdapter(requireContext(), arrayListOf(), resources.getStringArray(R.array.sticker))
             stickerRv.adapter = stickerAdapter
+
+            stickermodel?.getStickerList(object: BooleanListCallback {
+                override fun booleanlistCallback(flag: Boolean, data: ArrayList<Boolean>?) {
+                    if(flag && data != null){
+                        stickermodel.setSticker(data)
+                        stickerAdapter.setData(data)
+                    }
+                }
+            })
         }
 
     }
@@ -42,60 +56,5 @@ class StickerFragment : Fragment() {
     override fun onDestroy() {
         super.onDestroy()
         _binding = null
-    }
-
-    private fun setStickerList(): ArrayList<SelectList> {
-        return arrayListOf(
-            SelectList(
-                sticker = R.drawable.sticker01,
-                name = "라우디",
-                isAdded = true
-            ),
-            SelectList(
-                sticker = R.drawable.sticker02,
-                name = "장미콩",
-                isAdded = true
-            ),
-            SelectList(
-                sticker = R.drawable.sticker03,
-                name = "단무지",
-                isAdded = true
-            ),
-            SelectList(
-                sticker = R.drawable.sticker04,
-                name = "빈",
-                isAdded = false
-            ),
-            SelectList(
-                sticker = R.drawable.sticker05,
-                name = "고구마",
-                isAdded = false
-            ),
-            SelectList(
-                sticker = R.drawable.sticker06,
-                name = "사랑니",
-                isAdded = true
-            ),
-            SelectList(
-                sticker = R.drawable.sticker07,
-                name = "보라뿔",
-                isAdded = true
-            ),
-            SelectList(
-                sticker = R.drawable.sticker08,
-                name = "꿀벌복숭",
-                isAdded = true
-            ),
-            SelectList(
-                sticker = R.drawable.sticker09,
-                name = "동동",
-                isAdded = false
-            ),
-            SelectList(
-                sticker = R.drawable.sticker10,
-                name = "엄지공주",
-                isAdded = false
-            ),
-        )
     }
 }

--- a/app/src/main/java/com/aligatorapt/duckdam/viewModel/ComplimentViewModel.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/viewModel/ComplimentViewModel.kt
@@ -3,8 +3,10 @@ package com.aligatorapt.duckdam.viewModel
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.aligatorapt.duckdam.dto.compliment.ComplimentRequestDto
 import com.aligatorapt.duckdam.dto.compliment.ComplimentResponseDto
 import com.aligatorapt.duckdam.model.ComplimentModel
+import com.aligatorapt.duckdam.retrofit.callback.ApiCallback
 import com.aligatorapt.duckdam.retrofit.callback.ComplimentsCallback
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
@@ -37,6 +39,22 @@ class ComplimentViewModel: ViewModel() {
         viewModelScope.launch {
             withContext(dispatcher){
                 ComplimentModel.findCompliments(callback)
+            }
+        }
+    }
+
+    fun generateCompliment(_data: ComplimentRequestDto, callback: ApiCallback){
+        viewModelScope.launch {
+            withContext(dispatcher){
+                ComplimentModel.generateCompliment(_data, callback)
+            }
+        }
+    }
+
+    fun findComplimentsByFromAndTo(_toId: Long, callback: ComplimentsCallback){
+        viewModelScope.launch {
+            withContext(dispatcher){
+                ComplimentModel.findComplimentsByFromAndTo(_toId, callback)
             }
         }
     }

--- a/app/src/main/java/com/aligatorapt/duckdam/viewModel/FriendViewModel.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/viewModel/FriendViewModel.kt
@@ -1,0 +1,60 @@
+package com.aligatorapt.duckdam.viewModel
+
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.aligatorapt.duckdam.dto.user.UserResponseDto
+import com.aligatorapt.duckdam.model.FriendModel
+import com.aligatorapt.duckdam.model.UserModel
+import com.aligatorapt.duckdam.retrofit.callback.ApiCallback
+import com.aligatorapt.duckdam.retrofit.callback.UserCallback
+import com.aligatorapt.duckdam.retrofit.callback.UserListCallback
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+class FriendViewModel: ViewModel() {
+    private var dispatcher: CoroutineDispatcher = Dispatchers.IO
+
+    val friends = MutableLiveData<List<UserResponseDto>?>()
+
+    fun setFriend(_data: ArrayList<UserResponseDto>?){
+        friends.value = _data
+    }
+
+    fun followFriend(_targetId: Long, callback: ApiCallback){
+        viewModelScope.launch{
+            withContext(dispatcher){
+                FriendModel.followFriend(_targetId,callback)
+            }
+        }
+    }
+
+    fun findMyFriend(callback: UserCallback){
+        viewModelScope.launch {
+            withContext(dispatcher){
+                FriendModel.findMyFriend(callback)
+            }
+        }
+    }
+
+    fun searchByName(_query: String, callback: UserListCallback){
+        viewModelScope.launch {
+            withContext(dispatcher){
+                UserModel.searchByName(_query, callback)
+            }
+        }
+    }
+}
+
+object FriendSingleton  {
+    private var model: FriendViewModel? = null
+
+    fun getInstance(): FriendViewModel? {
+        if (model == null) {
+            model = FriendViewModel()
+        }
+        return model
+    }
+}

--- a/app/src/main/java/com/aligatorapt/duckdam/viewModel/LoginViewModel.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/viewModel/LoginViewModel.kt
@@ -1,8 +1,10 @@
 package com.aligatorapt.duckdam.viewModel
 
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.aligatorapt.duckdam.dto.user.LoginRequestDto
+import com.aligatorapt.duckdam.dto.user.UserResponseDto
 import com.aligatorapt.duckdam.model.UserModel
 import com.aligatorapt.duckdam.retrofit.callback.ApiCallback
 import kotlinx.coroutines.CoroutineDispatcher
@@ -13,11 +15,28 @@ import kotlinx.coroutines.withContext
 class LoginViewModel: ViewModel() {
     private var dispatcher: CoroutineDispatcher = Dispatchers.IO
 
+    val user = MutableLiveData<UserResponseDto>()
+
+    fun setUser(_user: UserResponseDto){
+        user.value = _user
+    }
+
     fun login(_loginRequestDto: LoginRequestDto, callback: ApiCallback){
         viewModelScope.launch {
             withContext(dispatcher){
                 UserModel.login(_loginRequestDto, callback)
             }
         }
+    }
+}
+
+object LoginSingleton  {
+    private var model: LoginViewModel? = null
+
+    fun getInstance(): LoginViewModel? {
+        if (model == null) {
+            model = LoginViewModel()
+        }
+        return model
     }
 }

--- a/app/src/main/java/com/aligatorapt/duckdam/viewModel/RegisterViewModel.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/viewModel/RegisterViewModel.kt
@@ -19,13 +19,13 @@ class RegisterViewModel: ViewModel() {
     private var dispatcher: CoroutineDispatcher = Dispatchers.IO
 
     val email = MutableLiveData<String>()
-    val profile = MutableLiveData<String?>()
+    val profile = MutableLiveData<ByteArray?>()
 
     fun setEmail(_email: String){
         email.value = _email
     }
 
-    fun setProfile(_profile: String){
+    fun setProfile(_profile: ByteArray){
         profile.value = _profile
     }
 

--- a/app/src/main/java/com/aligatorapt/duckdam/viewModel/StickerViewModel.kt
+++ b/app/src/main/java/com/aligatorapt/duckdam/viewModel/StickerViewModel.kt
@@ -1,0 +1,41 @@
+package com.aligatorapt.duckdam.viewModel
+
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.aligatorapt.duckdam.model.UserModel
+import com.aligatorapt.duckdam.retrofit.callback.BooleanListCallback
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+class StickerViewModel: ViewModel() {
+    private var dispatcher: CoroutineDispatcher = Dispatchers.IO
+
+    val stickers = MutableLiveData<List<Boolean>?>()
+
+    fun setSticker(_data: ArrayList<Boolean>?){
+        stickers.value = _data
+    }
+
+
+    fun getStickerList(callback: BooleanListCallback){
+        viewModelScope.launch {
+            withContext(dispatcher){
+                UserModel.getStickerList(callback)
+            }
+        }
+    }
+}
+
+object StickerSingleton  {
+    private var model: StickerViewModel? = null
+
+    fun getInstance(): StickerViewModel? {
+        if (model == null) {
+            model = StickerViewModel()
+        }
+        return model
+    }
+}

--- a/app/src/main/res/layout/activity_friendlist_detail.xml
+++ b/app/src/main/res/layout/activity_friendlist_detail.xml
@@ -90,6 +90,47 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent" />
 
+        <LinearLayout
+            android:id="@+id/emptyResult"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="@color/sub2"
+            android:gravity="center"
+            android:orientation="vertical"
+            android:visibility="gone"
+            app:layout_constraintTop_toBottomOf="@id/fldetail_compliment"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent">
+
+            <ImageView
+                android:id="@+id/imageView"
+                android:layout_width="300dp"
+                android:layout_height="300dp"
+                android:layout_marginBottom="20dp"
+                android:src="@drawable/empty_result" />
+
+            <TextView
+                android:id="@+id/textView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="4dp"
+                android:gravity="center"
+                android:text="아직 칭찬 내역이 없어요."
+                android:textColor="@color/black"
+                android:textSize="16sp" />
+
+            <TextView
+                android:id="@+id/textView2"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:text="먼저 칭찬하는 것은 어떨까요?"
+                android:textColor="@color/black"
+                android:textSize="16sp" />
+
+        </LinearLayout>
+
     </androidx.constraintlayout.widget.ConstraintLayout>
 
 </com.amar.library.ui.StickyScrollView>

--- a/app/src/main/res/layout/activity_friendlist_detail.xml
+++ b/app/src/main/res/layout/activity_friendlist_detail.xml
@@ -97,18 +97,12 @@
             android:background="@color/sub2"
             android:gravity="center"
             android:orientation="vertical"
+            android:layout_marginTop="200dp"
             android:visibility="gone"
             app:layout_constraintTop_toBottomOf="@id/fldetail_compliment"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintBottom_toBottomOf="parent">
-
-            <ImageView
-                android:id="@+id/imageView"
-                android:layout_width="300dp"
-                android:layout_height="300dp"
-                android:layout_marginBottom="20dp"
-                android:src="@drawable/empty_result" />
 
             <TextView
                 android:id="@+id/textView"

--- a/app/src/main/res/layout/activity_signup.xml
+++ b/app/src/main/res/layout/activity_signup.xml
@@ -106,7 +106,7 @@
                 android:id="@+id/signup_code"
                 android:layout_width="0dp"
                 android:layout_height="50dp"
-                android:inputType="text|textNoSuggestions"
+                android:inputType="number"
                 android:hint="인증 코드를 입력하세요."
                 android:textSize="14sp"
                 android:textColor="@color/black"

--- a/app/src/main/res/layout/activity_signup.xml
+++ b/app/src/main/res/layout/activity_signup.xml
@@ -265,21 +265,6 @@
                 app:layout_constraintStart_toEndOf="@id/signup_nickname_tv"
                 app:layout_constraintTop_toTopOf="@id/signup_nickname_tv" />
 
-            <TextView
-                android:id="@+id/signup_nickname_check"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:paddingVertical="8dp"
-                android:paddingHorizontal="17dp"
-                android:layout_marginEnd="35dp"
-                android:text="중복 확인"
-                android:textSize="12sp"
-                android:textColor="@color/white"
-                android:background="@drawable/sub1_solid_box_10dp"
-                app:layout_constraintTop_toTopOf="@id/signup_nickname_tv"
-                app:layout_constraintBottom_toBottomOf="@id/signup_nickname_tv"
-                app:layout_constraintEnd_toEndOf="parent"/>
-
             <EditText
                 android:id="@+id/signup_nickname"
                 android:layout_width="match_parent"

--- a/app/src/main/res/layout/dialog_friendlist.xml
+++ b/app/src/main/res/layout/dialog_friendlist.xml
@@ -61,6 +61,15 @@
             tools:listitem="@layout/row_dialog"
             app:layout_constraintTop_toBottomOf="@id/layout"/>
 
+        <View
+            android:id="@+id/row_view"
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="@color/gray2"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/friendlist"/>
+
         <LinearLayout
             android:id="@+id/emptyResult"
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/dialog_friendlist.xml
+++ b/app/src/main/res/layout/dialog_friendlist.xml
@@ -61,6 +61,39 @@
             tools:listitem="@layout/row_dialog"
             app:layout_constraintTop_toBottomOf="@id/layout"/>
 
+        <LinearLayout
+            android:id="@+id/emptyResult"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:gravity="center_vertical"
+            android:orientation="vertical"
+            android:layout_marginTop="200dp"
+            app:layout_constraintTop_toBottomOf="@id/view"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            android:visibility="gone">
+
+            <TextView
+                android:id="@+id/textView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="4dp"
+                android:gravity="center"
+                android:text="친구 목록이 없어요."
+                android:textColor="@color/black"
+                android:textSize="16sp" />
+
+            <TextView
+                android:id="@+id/textView2"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:text="친구 검색을 통해 친구를 추가해보세요!"
+                android:textColor="@color/black"
+                android:textSize="16sp" />
+        </LinearLayout>
+
     </androidx.constraintlayout.widget.ConstraintLayout>
 
 

--- a/app/src/main/res/layout/fragment_friendlist.xml
+++ b/app/src/main/res/layout/fragment_friendlist.xml
@@ -11,7 +11,7 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="match_parent">
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/friendList_header"
@@ -71,6 +71,7 @@
             android:id="@+id/friendlist_howmany_layout"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:paddingBottom="15dp"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toBottomOf="@id/friendList_header">
@@ -87,7 +88,7 @@
                 android:id="@+id/friendnum"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="2"
+                android:text="  "
                 android:textSize="30sp"
                 android:textStyle="bold"
                 android:textColor="@color/black"
@@ -103,25 +104,16 @@
 
         </LinearLayout>
 
-        <View
-            android:id="@+id/view"
-            android:layout_width="match_parent"
-            android:layout_height="1dp"
-            android:background="@color/gray2"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintBottom_toTopOf="@id/friendlist_rv"/>
-
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/friendlist_rv"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:overScrollMode="never"
-            android:layout_marginTop="15dp"
+            android:visibility="gone"
             app:layout_constraintTop_toBottomOf="@id/friendlist_howmany_layout"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            tools:listitem="@layout/row_dialog"/>
+            tools:listitem="@layout/row_friendlist"/>
 
         <View
             android:id="@+id/row_bottomview"
@@ -131,6 +123,39 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toBottomOf="@id/friendlist_rv"/>
+
+        <LinearLayout
+            android:id="@+id/emptyResult"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:gravity="center_vertical"
+            android:orientation="vertical"
+            android:layout_marginTop="200dp"
+            app:layout_constraintTop_toBottomOf="@id/friendlist_howmany_layout"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            android:visibility="visible">
+
+            <TextView
+                android:id="@+id/textView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="4dp"
+                android:gravity="center"
+                android:text="친구 목록이 없어요."
+                android:textColor="@color/black"
+                android:textSize="16sp" />
+
+            <TextView
+                android:id="@+id/textView2"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:text="친구 검색을 통해 친구를 추가해보세요!"
+                android:textColor="@color/black"
+                android:textSize="16sp" />
+        </LinearLayout>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/fragment_friendlist.xml
+++ b/app/src/main/res/layout/fragment_friendlist.xml
@@ -109,7 +109,6 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:overScrollMode="never"
-            android:visibility="gone"
             app:layout_constraintTop_toBottomOf="@id/friendlist_howmany_layout"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/row_friendlist.xml
+++ b/app/src/main/res/layout/row_friendlist.xml
@@ -39,4 +39,21 @@
         app:layout_constraintBottom_toBottomOf="@id/row_sticker"
         app:layout_constraintStart_toEndOf="@id/row_sticker"/>
 
+
+    <TextView
+        android:id="@+id/row_add"
+        android:layout_width="70dp"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="33dp"
+        android:background="@drawable/main_solid_box_5dp"
+        android:gravity="center"
+        android:text="추가하기"
+        android:textSize="12sp"
+        android:paddingVertical="5dp"
+        android:paddingHorizontal="10dp"
+        android:textColor="@color/white"
+        app:layout_constraintBottom_toBottomOf="@+id/row_name"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="@+id/row_name" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/row_friendlistdetail.xml
+++ b/app/src/main/res/layout/row_friendlistdetail.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="wrap_content"
+    android:layout_width="match_parent"
     android:layout_height="wrap_content"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:padding="10dp"
@@ -35,6 +35,7 @@
         android:layout_height="wrap_content"
         android:layout_marginHorizontal="30dp"
         android:layout_marginVertical="20dp"
+        android:paddingStart="5dp"
         android:singleLine="false"
         android:text="오늘 하루 도움을 줘서 너무 고마워! 네가 없었으면 우리 팀은 이기지 못했을 거야 :)"
         android:textColor="@color/black"

--- a/app/src/main/res/layout/row_sticker.xml
+++ b/app/src/main/res/layout/row_sticker.xml
@@ -34,7 +34,7 @@
             android:layout_height="25dp"
             android:text="사랑니"
             android:gravity="center"
-            android:textSize="16sp"
+            android:textSize="14sp"
             android:textColor="@color/black"
             android:layout_marginVertical="5dp"
             app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
## 개요
- 칭찬 보내기, 친구 목록, 친구 검색, 스티커판, 칭찬 목록 가져오기 API 연결

## 상세내용
- 홈에서 친구목록을 가져오도록 수정하였습니다. 
- 친구 목록, 검색 결과, 칭찬 목록이 없다면 해당 결과에 대한 문구를 띄웁니다. 
- 검색화면에 자기자신과 친구 또한 뜨며, 그 외의 사용자 옆엔 추가하기 버튼이 뜹니다.
- 추가하기 버튼을 클릭하면, 상단의 친구 수가 갱신됩니다.
- 로그인 시 반환되는 현재 사용자의 정보를 LoginViewModel의 user에 저장합니다. 

## 기타
- 단말기의 세로 길이가 짧은 경우, 홈화면과 자판기 화면의 하단 부분이 짤리는 문제가 있습니다. Scrollview를 상단에 달아주면 좋을거 같아요!
- 자판기 결과 화면에서 스티커판으로 넘어갈 때 ComplimentResponse가 null이라는 오류가 발생합니다. 확인 부탁드려요!